### PR TITLE
Fix for stale entries in config

### DIFF
--- a/subcommands/pull.js
+++ b/subcommands/pull.js
@@ -167,12 +167,12 @@ const pull = async (componentName, { cwd = '.' }) => {
           availableName,
           metaData.BlockType,
           metaData.GitUrl,
-          false,
+          appConfig.isOutOfContext,
           cwd
         )
 
         clonePath = createBlockRes.clonePath
-        cloneDirName = createBlockRes.name
+        cloneDirName = createBlockRes.cloneDirName
         blockFinalName = createBlockRes.blockFinalName
       }
 

--- a/subcommands/pull/forkUtil.js
+++ b/subcommands/pull/forkUtil.js
@@ -233,12 +233,13 @@ const forkRepo = (metaData, newBlockName, clonePath) =>
       })
 
       spinnies.update('fork', { text: `Registering block` })
-      await registerBlock(BlockType, name, name, visibility === 'PUBLIC', sshUrl, description)
+      await registerBlock(BlockType, name, name, true, sshUrl, description)
       spinnies.update('fork', { text: `Registered block` })
 
       spinnies.succeed('fork', { text: `Successfully forked` })
       resolve({ description, visibility, url, sshUrl, name, blockFinalName })
     } catch (err) {
+      spinnies.add('fork')
       spinnies.fail('fork', { text: `Failed to fork` })
       reject(err)
     }


### PR DESCRIPTION
This PR includes,

spinner not initialized error in fork fix,

all forks will be public,

config-manager checks for the existence of block after reading from json, and is removed if not present

pulling and creating a new variant with clone is fixed.