### PR TITLE
Purchased block pull

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -19,6 +19,11 @@ const { blockTypes } = require('../utils/blockTypes')
 const packageBlockInit = require('../subcommands/init')
 // const { isGitInstalled, isInGitRepository } = require('../utils/gitCheckUtils')
 // const { ensureUserLogins } = require('../utils/ensureUserLogins')
+const deploy = require('../subcommands/deploy')
+const createEnv = require('../subcommands/createEnv')
+const upload = require('../subcommands/upload')
+const provisionApp = require('../subcommands/provisionApp')
+const deleteApp = require('../subcommands/deleteApp')
 
 const log = require('../subcommands/log')
 const start = require('../subcommands/start')
@@ -51,6 +56,7 @@ const updateLanguageVersionCommand = require('../subcommands/languageVersion/upd
 const deleteCommand = require('../subcommands/delete')
 const listLanguageVersionCommand = require('../subcommands/languageVersion/list')
 const createBlockVersion = require('../subcommands/createBlockVersion/index')
+const getBlockUpdate = require('../subcommands/getBlockUpdate')
 
 inquirer.registerPrompt('file-tree-selection', inquirerFileTree)
 inquirer.registerPrompt('customList', customList)
@@ -70,8 +76,7 @@ async function init() {
   // init local registry
 
   const program = new Command().hook('preAction', async (_, actionCommand) => {
-    const subcommand = actionCommand.parent.args[0]
-    await preActionChecks(subcommand)
+    await preActionChecks(actionCommand)
   })
 
   // TODO -- get version properly
@@ -112,12 +117,14 @@ async function init() {
         }, [])
       )
     )
+    .option('--no-repo')
     .description('to create components')
     .action(create)
 
   program
     .command('init')
     .argument('<appblock-name>', 'Name of app')
+    .option('--no-repo')
     .description('create an appblock')
     .action(packageBlockInit)
 
@@ -173,6 +180,8 @@ async function init() {
     .option('--no-variant', 'No variant')
     .option('-t, --type <variantType>', 'Type of variant to create')
     .action(pull)
+
+  program.command('get-update').argument('<component>', 'Name of component').action(getBlockUpdate)
 
   program.command('push-config').action(push_config)
 
@@ -240,6 +249,32 @@ async function init() {
     .option('-g, --global', 'execute globally')
     .description('Delete block component')
     .action(deleteCommand)
+  
+  program
+    .command('deploy')
+    .option('-rv, --release-version <release_version>', 'version number')
+    .option('-rn, --release-note <release_note>', 'release note')
+    .option('-env, --environment <environment>', 'environment')
+    .description('deploy app')
+    .action(deploy)
+    
+  program.command('delete-app').description('Delete app').action(deleteApp)
+
+  program
+    .command('provision-app')
+    .argument('<app_id>', 'Id of app to provision')
+    .description('provision app for deploy')
+    .action(provisionApp)
+
+  program.command('create-env').description('create env for deploy').action(createEnv)
+
+  program
+    .command('upload')
+    .argument('[block]', 'name of block or block type')
+    .requiredOption('-env, --environment <environment>', 'environment')
+    .description('upload block for deploy')
+    .action(upload)
+  
 
   program.parseAsync(process.argv)
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,17 @@
   "bin": {
     "bb": "./bin/index.js"
   },
+  "engines": {
+    "npm": ">=8.0.0 <9.0.0",
+    "node": ">=15.0.0 <17.0.0"
+  },
   "scripts": {
     "prepare": "npx husky install",
     "test": "npx jest",
     "lint": "npx eslint *.js bin/ utils/ --fix",
     "format": "npx prettier ./**/*{.js,.json} --write",
-    "pre-commit": "npx lint-staged"
+    "pre-commit": "npx lint-staged",
+    "start-block": ""
   },
   "lint-staged": {
     "*.js": [
@@ -22,6 +27,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-application-auto-scaling": "^3.209.0",
+    "@aws-sdk/client-ec2": "^3.200.0",
+    "@aws-sdk/client-ecr": "^3.198.0",
+    "@aws-sdk/client-ecs": "^3.199.0",
+    "@aws-sdk/client-elastic-load-balancing": "^3.202.0",
+    "@aws-sdk/client-elastic-load-balancing-v2": "^3.202.0",
+    "@aws-sdk/client-s3": "^3.211.0",
     "@babel/parser": "^7.17.9",
     "ansi-escapes": "4.3.2",
     "axios": "0.21.4",
@@ -44,6 +56,8 @@
     "inquirer": "8.1.5",
     "inquirer-autocomplete-prompt": "1.4.0",
     "inquirer-file-tree-selection-prompt": "1.0.12",
+    "is-running": "^2.1.0",
+    "mime-types": "^2.1.35",
     "node-cron": "^3.0.2",
     "octokit": "1.7.1",
     "open": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appblocks/bb-cli",
-  "version": "0.7.1",
+  "version": "0.12.4",
   "description": "CLI tool to create, manage and publish Blocks to Blocks Registry.",
   "main": "./bin/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appblocks/bb-cli",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "CLI tool to create, manage and publish Blocks to Blocks Registry.",
   "main": "./bin/index.js",
   "bin": {

--- a/subcommands/__tests__/createApp.test.js
+++ b/subcommands/__tests__/createApp.test.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable */
+const createApp = require('../createApp')
+const { readInput } = require('../../utils/questionPrompts')
+const { default: axios } = require('axios')
+const { getBlockConfig, getBlockId } = require('../../utils/deployUtil')
+const { getShieldHeader } = require('../../utils/getHeaders')
+const deployConfig = require('../../utils/deployConfig-manager')
+const { appRegistryCreateApp } = require('../../utils/api')
+
+jest.mock('../../utils/questionPrompts')
+jest.mock('../../utils/deployUtil')
+jest.mock('../../utils/deployConfig-manager')
+jest.mock('axios')
+
+describe('Create App command', () => {
+  beforeAll(() => {})
+
+  test('should creating saas app', async () => {
+    const appName = 'saas-app'
+    const envName = 'dev'
+    const deploymentMode = 0
+    const subDomain = 'saas-app-dev'
+    const appBlockId = 'saas-app-block-id'
+
+    readInput.mockResolvedValueOnce(deploymentMode)
+    readInput.mockResolvedValueOnce(appName)
+    readInput.mockResolvedValueOnce(envName)
+    readInput.mockResolvedValueOnce(subDomain)
+
+    getBlockConfig.mockReturnValueOnce({ name: 'saas-app-block' })
+    getBlockId.mockResolvedValueOnce(appBlockId)
+
+    const postData = {
+      app_block_id: appBlockId,
+      app_name: appName,
+      environment_name: envName,
+      deployment_mode: deploymentMode,
+      sub_domain: subDomain,
+    }
+
+    const postRes = {
+      app_id: 'app_id',
+      app_name: appName,
+      environment_name: envName,
+      deployment_mode: deploymentMode,
+      environment_id: 'environment_id',
+      backend_url: subDomain + 'functions-Appblocks.com',
+      frontend_url: subDomain + 'Appblocks.com',
+    }
+
+    axios.post = jest
+      .fn()
+      .mockResolvedValueOnce(
+        Promise.resolve({ data: { data: { ...postRes }, success: true, message: 'App created successfully' } })
+      )
+
+    await createApp()
+
+    expect(axios.post).toHaveBeenCalledWith(appRegistryCreateApp, postData, {
+      headers: getShieldHeader(),
+    })
+
+    // expect(deployConfig.createDeployConfig).toHaveBeenCalled()
+  })
+
+  test('should creating erp app', async () => {
+    const appName = 'erp-app'
+    const envName = 'Production'
+    const deploymentMode = 1
+    const subDomain = ''
+    const appBlockId = 'erp-app-block-id'
+
+    readInput.mockResolvedValueOnce(deploymentMode)
+    readInput.mockResolvedValueOnce(appName)
+
+    getBlockConfig.mockReturnValueOnce({ name: 'erp-app-block' })
+    getBlockId.mockResolvedValueOnce(appBlockId)
+
+    const postData = {
+      app_block_id: appBlockId,
+      app_name: appName,
+      environment_name: envName,
+      deployment_mode: deploymentMode,
+      sub_domain: subDomain,
+    }
+
+    const postRes = {
+      app_id: 'app_id',
+      app_name: appName,
+      environment_name: envName,
+      deployment_mode: deploymentMode,
+      environment_id: 'environment_id',
+    }
+
+    axios.post = jest
+      .fn()
+      .mockResolvedValueOnce(
+        Promise.resolve({ data: { data: { ...postRes }, success: true, message: 'App created successfully' } })
+      )
+    await createApp()
+
+    expect(axios.post).toHaveBeenCalledWith(appRegistryCreateApp, postData, {
+      headers: getShieldHeader(),
+    })
+  })
+
+  test('should exit with error', async () => {
+    expect(async () => {
+      await createApp()
+    }).rejects.toThrow("Cannot read properties of undefined (reading 'name')")
+  })
+})

--- a/subcommands/appPublish.js
+++ b/subcommands/appPublish.js
@@ -1,0 +1,195 @@
+/* eslint-disable no-continue */
+
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { rm } = require('fs')
+const path = require('path')
+const chalk = require('chalk')
+const { default: axios } = require('axios')
+const { getBBConfig } = require('../utils/config-manager')
+const { appRegistryUploadBlockStatus, appRegistryCheckAppEnvExist } = require('../utils/api')
+const { getShieldHeader } = require('../utils/getHeaders')
+const deployConfig = require('./deploy/manager')
+const { spinnies } = require('../loader')
+const { getPublishedVersion } = require('./publish/util')
+const { appConfig } = require('../utils/appconfigStore')
+const { createZip, uploadToServer } = require('./upload/util')
+const { logFail } = require('../utils')
+
+const appPublish = async () => {
+  deployConfig.init()
+  await appConfig.init()
+
+  const { dependencies } = await getBBConfig()
+  const appData = deployConfig.deployAppConfig
+  const appId = appData.app_id
+
+  if (!appId) {
+    logFail(`\nPlease create app before publish..`)
+    process.exit(1)
+  }
+
+  const environment = 'Production'
+  const envData = appData.environments[environment]
+
+  if (!envData) {
+    logFail(`${environment} environment not exist. Please create-env and try again\n`)
+
+    const envs = Object.keys(appData.environments)
+    if (envs.length) {
+      console.log(chalk.gray(`Existing environments are ${envs}\n`))
+    }
+
+    process.exit(1)
+  }
+
+  const preparedForUpload = []
+  const uploadStatus = []
+
+  spinnies.add('up', { text: `Checking app details` })
+
+  // Check if app and env exist in server
+  try {
+    const { data: resData } = await axios.post(
+      `${appRegistryCheckAppEnvExist}`,
+      {
+        app_id: appId,
+        environment_id: envData.environment_id,
+      },
+      {
+        headers: getShieldHeader(),
+      }
+    )
+
+    const { data } = resData
+
+    if (!data.app_exist || !data.env_exist) {
+      const dpath = path.resolve(deployConfig.configName)
+      spinnies.fail('up', { text: ` ${!data.app_exist ? 'App' : 'Environment'} does not exist` })
+      rm(dpath, () => {
+        process.exit(1)
+      })
+    }
+  } catch (error) {
+    console.log(error)
+    spinnies.fail('up', { text: 'Error checking app data' })
+    process.exit(1)
+  }
+
+  /**
+   * UPLOAD ALL Block
+   */
+  spinnies.add('up', { text: `Uploading ${'all'} block` })
+
+  for (const blockData of Object.values(dependencies)) {
+    const {
+      meta: { type, name },
+      directory,
+    } = blockData
+
+    spinnies.update('up', { text: `Preparing ${name} block to upload` })
+
+    const { success, latestVersion, msg } = getPublishedVersion(name, directory)
+
+    if (!success || !latestVersion) {
+      preparedForUpload.push({
+        success: false,
+        blockName: name,
+        latestVersion,
+        directory,
+        msg: latestVersion ? msg : `No published version found -> block ${name}`,
+      })
+      continue
+    }
+
+    const blockId = await appConfig.getBlockId(name)
+
+    if (['ui-container', 'ui-elements'].includes(type)) {
+      const zipFile = await createZip({ directory, blockName: name, type })
+      preparedForUpload.push({
+        success: true,
+        blockType: type,
+        blockFolder: directory,
+        appId,
+        blockId,
+        zipFile,
+        blockName: name,
+        version: latestVersion,
+        environmentId: envData.environment_id,
+      })
+    } else {
+      const zipFile = await createZip({ directory, blockName: name })
+      preparedForUpload.push({
+        success: true,
+        blockType: type,
+        blockFolder: directory,
+        appId,
+        blockId,
+        zipFile,
+        blockName: name,
+        version: latestVersion,
+        environmentId: envData.environment_id,
+      })
+    }
+  }
+
+  // Check if any block has error
+  if (preparedForUpload.some((v) => !v.success)) {
+    spinnies.fail('up', { text: 'Error preparing upload block' })
+    preparedForUpload.forEach((v) => {
+      if (v.msg) logFail(v.msg)
+    })
+    process.exit(1)
+  }
+
+  for (const bData of preparedForUpload) {
+    const uploadedRes = await uploadToServer(bData)
+    uploadStatus.push({ ...uploadedRes, blockName: bData.blockName })
+  }
+
+  try {
+    // TODO handle unsuccessful blocks
+    if (uploadStatus.some((v) => v.success === false)) {
+      uploadStatus.forEach((v) => {
+        if (v.msg) logFail(v.msg)
+      })
+      spinnies.fail('up', { text: 'Error uploading block' })
+      return
+    }
+
+    spinnies.update('up', { text: `Setting uploaded blocks` })
+
+    const uploadedDataRes = await axios.post(
+      appRegistryUploadBlockStatus,
+      {
+        metadata: {},
+        request_blocks: uploadStatus,
+        environment_id: envData.environment_id,
+        tags: 'tag',
+      },
+      {
+        headers: getShieldHeader(),
+      }
+    )
+    const { deploy_id } = uploadedDataRes.data.data
+
+    // rm tmp file
+    rm(path.resolve('./.tmp'), { recursive: true }, () => {})
+
+    spinnies.succeed('up', {
+      text: `App uploaded successfully. ID : ${deploy_id} `,
+    })
+  } catch (error) {
+    // rm tmp file
+    rm(path.resolve('./.tmp'), { recursive: true }, () => {})
+
+    spinnies.fail('up', { text: 'Error saving upload block' })
+  }
+}
+
+module.exports = appPublish

--- a/subcommands/bash.js
+++ b/subcommands/bash.js
@@ -52,28 +52,28 @@ async function runBash(command, dir) {
 }
 
 function runBashLongRunning(command, loggers, dir) {
-  try {
-    // const bashOut = exec(command);
-    // console.log('directory for child is =', dir)
-    // console.log('loggesrs are ', loggers)
-    const out = fs.openSync(getAbsPath(loggers.out), 'w')
-    const err = fs.openSync(getAbsPath(loggers.err), 'w')
-    const commandArr = command.split(' ')
-    const com = commandArr[0]
-    commandArr.shift()
-    const child = cp.spawn(com, commandArr, {
-      cwd: dir,
-      detached: true,
-      stdio: ['ignore', out, err],
-      env: { ...process.env, parentPath: global.rootDir },
-    })
-    child.unref()
-    // console.log('child unreffed....', child.pid)
-    return child
-  } catch (err) {
-    console.error(err)
-    return null
-  }
+  // try {
+  // const bashOut = exec(command);
+  // console.log('directory for child is =', dir)
+  // console.log('loggesrs are ', loggers)
+  const out = fs.openSync(getAbsPath(loggers.out), 'w')
+  const err = fs.openSync(getAbsPath(loggers.err), 'w')
+  const commandArr = command.split(' ')
+  const com = commandArr[0]
+  commandArr.shift()
+  const child = cp.spawn(com, commandArr, {
+    cwd: dir,
+    detached: true,
+    stdio: ['ignore', out, err],
+    env: { ...process.env, parentPath: global.rootDir },
+  })
+  child.unref()
+  // console.log('child unreffed....', child.pid)
+  return child
+  // } catch (err) {
+  //   console.error(err)
+  //   return null
+  // }
 }
 
 module.exports = { runBashLongRunning, runBash, runScript }

--- a/subcommands/createApp.js
+++ b/subcommands/createApp.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable camelcase */
+// const { transports } = require('winston')
+const { default: axios } = require('axios')
+const { readInput } = require('../utils/questionPrompts')
+// const { logger } = require('../utils/logger')
+const { appRegistryCreateApp } = require('../utils/api')
+const { getShieldHeader } = require('../utils/getHeaders')
+const { getBlockConfig, getBlockId } = require('./deploy/util')
+
+const deployConfig = require('./deploy/manager')
+const { spinnies } = require('../loader')
+
+// logger.add(new transports.File({ filename: 'create.log' }))
+
+const createApp = async () => {
+  deployConfig.init()
+  const appConfig = await deployConfig.deployAppConfig
+
+  if (appConfig?.app_id) {
+    console.log(`${appConfig.app_name} app already exist`)
+    process.exit(1)
+  }
+
+  // logger.info('------------------------------------------------------------')
+  try {
+    // const deploymentMode = await readInput({
+    //   type: 'list',
+    //   name: 'deploymentMode',
+    //   message: 'Select the app deployment mode',
+    //   choices: ['SaaS', 'Business (ERP)'].map((v, i) => ({
+    //     name: v,
+    //     value: i,
+    //   })),
+    // })
+    const deploymentMode = 0
+
+    const appName = await readInput({
+      name: 'appName',
+      message: 'Enter the app name',
+      validate: (input) => {
+        if (!input || input?.length < 3) return `Please enter the app name with atleast 3 characters`
+        return true
+      },
+    })
+
+    let envName = 'production'
+    const subDomain = ''
+
+    if (deploymentMode === 0) {
+      envName = await readInput({
+        name: 'envName',
+        message: 'Enter the app environment name',
+        validate: (input) => {
+          if (!input || input?.length < 3) return `Please enter the environment name with atleast 3 characters`
+          return true
+        },
+        default: 'Production',
+      })
+      // NOTE: asking domain name should be enabled once appblocks prem is live
+      //   subDomain = await readInput({
+      //     name: 'subDomain',
+      //     message: 'Enter the sub domain name',
+      //     validate: async (ans) => {
+      //       try {
+      //         // if (/[a-z\-]+/g.test(ans)) {
+      //         //   return `Should only contain aplha numeric characters, hyphen`
+      //         // }
+      //         const subDomainCheck = await axios.post(
+      //           appRegistryCheckDomainName,
+      //           { sub_domain: ans },
+      //           {
+      //             headers: getShieldHeader(),
+      //           }
+      //         )
+      //         if (subDomainCheck.data?.data?.exists) return `${ans} already taken`
+      //         return true
+      //       } catch (error) {
+      //         console.log(`Error checking domain name exist`, error)
+      //         return `Error checking domain name exist`
+      //       }
+      //     },
+      //     default: `${envName}-${appName}`.toLocaleLowerCase(),
+      //   })
+    }
+
+    // TODO: Check name availability
+
+    spinnies.add('ca', { text: `Creating ${appName} app` })
+
+    const appBlockConfig = getBlockConfig()
+    const appBlockId = await getBlockId(appBlockConfig.name)
+
+    const createData = {
+      app_block_id: appBlockId,
+      app_name: appName,
+      environment_name: envName,
+      deployment_mode: deploymentMode,
+      sub_domain: subDomain,
+    }
+
+    const registerAppRes = await axios.post(appRegistryCreateApp, createData, {
+      headers: getShieldHeader(),
+    })
+
+    const { data } = registerAppRes.data
+
+    const { app_id, app_name, environment_name, ...envDomainData } = data
+
+    const appData = {
+      app_id,
+      app_name,
+      deployment_mode: deploymentMode,
+      environments: {
+        [environment_name]: {
+          environment_id: envDomainData.environment_id,
+        },
+      },
+    }
+
+    if (deploymentMode === 0) {
+      if (!envDomainData.backend_url) delete envDomainData.backend_url
+      if (!envDomainData.frontend_url) delete envDomainData.frontend_url
+      appData.environments[environment_name] = envDomainData
+    }
+
+    deployConfig.createDeployConfig = appData
+
+    spinnies.succeed('ca', { text: 'App created successfully' })
+  } catch (err) {
+    spinnies.fail('ca', { text: err.message })
+    // console.log(err)
+  }
+}
+
+module.exports = createApp

--- a/subcommands/createEnv.js
+++ b/subcommands/createEnv.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { default: axios } = require('axios')
+const chalk = require('chalk')
+const { readInput } = require('../utils/questionPrompts')
+const { getShieldHeader } = require('../utils/getHeaders')
+const { appRegistryCreateEnv, appRegistryCheckDomainName } = require('../utils/api')
+
+const deployConfig = require('./deploy/manager')
+const { spinnies } = require('../loader')
+
+const envCreate = async () => {
+  deployConfig.init()
+  const appConfig = deployConfig.deployAppConfig
+
+  const appId = appConfig?.app_id
+  if (!appId) {
+    console.log(chalk.red(`Please create app before upload..\n`))
+    process.exit(1)
+  }
+
+  const envNames = Object.keys(appConfig.environments)
+
+  const envName = await readInput({
+    name: 'envName',
+    message: 'Enter the environment name',
+    validate: async (ans) => {
+      if (envNames.includes(ans)) return `${ans} already  exist`
+      return true
+    },
+  })
+
+  const subDomain = await readInput({
+    name: 'subDomain',
+    message: 'Enter the environment sub domain',
+    validate: async (ans) => {
+      try {
+        // if (/[a-z\-]+/g.test(ans)) {
+        //   return `Should only contain aplha numeric characters, hyphen`
+        // }
+        const subDomainCheck = await axios.post(
+          appRegistryCheckDomainName,
+          { sub_domain: ans },
+          {
+            headers: getShieldHeader(),
+          }
+        )
+        if (subDomainCheck.data?.data?.exists) return `${ans} already taken`
+        return true
+      } catch (error) {
+        console.log(`Error checking domain name exist`, error)
+        return `Error checking domain name exist`
+      }
+    },
+    default: `${appConfig.app_name}-${envName}`,
+  })
+
+  const createData = {
+    app_id: appId,
+    sub_domain: subDomain,
+    environment_name: envName,
+  }
+
+  try {
+    spinnies.add('ce', { text: `Creating ${envName} environment..` })
+
+    const createEnvRes = await axios.post(appRegistryCreateEnv, createData, {
+      headers: getShieldHeader(),
+    })
+
+    const { app_id, ...newEnvData } = createEnvRes.data.data
+
+    deployConfig.upsertDeployConfig = {
+      name: 'environments',
+      data: { ...appConfig.environments, [envName]: newEnvData },
+    }
+
+    spinnies.succeed('ce', {
+      text: `Created ${envName} environment successfully`,
+    })
+  } catch (err) {
+    console.log(err.message || err)
+    console.log('Something went wrong while creating!')
+  }
+
+  // const appConfig = getBlockConfig()
+  // const blockId = await getBlockId(appConfig.name)
+  // console.log("🚀 ~ file: envCreate.js ~ line 30 ~ envCreate ~ blockId", blockId)
+}
+
+module.exports = envCreate

--- a/subcommands/deleteApp.js
+++ b/subcommands/deleteApp.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable camelcase */
+const { default: axios } = require('axios')
+const { rm } = require('fs')
+const path = require('path')
+
+const { getShieldHeader } = require('../utils/getHeaders')
+const { appRegistryDeleteApp } = require('../utils/api')
+const deployConfig = require('./deploy/manager')
+const { spinnies } = require('../loader')
+const { confirmationPrompt } = require('../utils/questionPrompts')
+
+const deleteApp = async () => {
+  deployConfig.init()
+  const appConfig = await deployConfig.deployAppConfig
+
+  if (!appConfig?.app_id) {
+    console.log(`No app found`)
+    process.exit(1)
+  }
+
+  const confirm = await confirmationPrompt({
+    name: 'deleteApp',
+    message: 'Do you want to delete the app?',
+    default: false,
+  })
+
+  if (!confirm) {
+    spinnies.add('da')
+    spinnies.succeed('da', { text: 'App deletion cancelled' })
+    return
+  }
+
+  spinnies.add('da', { text: `Deleting ${appConfig.app_name} app` })
+
+  // logger.info('------------------------------------------------------------')
+  try {
+    await axios.post(
+      appRegistryDeleteApp,
+      { app_id: appConfig.app_id },
+      {
+        headers: getShieldHeader(),
+      }
+    )
+
+    rm(path.resolve(deployConfig.cwd, deployConfig.configName), () => {})
+
+    spinnies.succeed('da', { text: 'App deleted successfully' })
+  } catch (err) {
+    spinnies.fail('da', { text: err.message })
+    console.log(err.message || err)
+  }
+}
+
+module.exports = deleteApp

--- a/subcommands/deploy/abPrem/index.js
+++ b/subcommands/deploy/abPrem/index.js
@@ -1,0 +1,124 @@
+/* eslint-disable no-param-reassign */
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const chalk = require('chalk')
+const { viewsDeploy, functionsDeploy, createDeployHistory, checkAppEnvExist } = require('../util')
+const { readInput } = require('../../../utils/questionPrompts')
+
+const { spinnies } = require('../../../loader')
+
+const abPremDeploy = async ({ argOpitons, deployConfigManager }) => {
+  const appData = deployConfigManager.deployAppConfig
+  const { releaseVersion, releaseNote } = argOpitons
+
+  const deployableData = Object.values(appData.environments).reduce((acc, envData) => {
+    if (envData.uploads) {
+      const deployIds = Object.keys(envData.uploads)
+      if (deployIds.length) return [...acc, ...deployIds]
+    }
+    return acc
+  }, [])
+
+  if (!deployableData.length) {
+    console.log(chalk.red(`No uploads found for deploy\n`))
+    process.exit(1)
+  }
+
+  const deployId = await readInput({
+    type: 'list',
+    name: 'deployId',
+    message: 'Select the deployment',
+    choices: deployableData.map((v) => ({
+      name: v,
+      value: v,
+    })),
+    default: deployableData[0],
+  })
+
+  const deployType = await readInput({
+    type: 'list',
+    name: 'deployType',
+    message: 'Select the deployment type',
+    choices: [
+      {
+        name: 'Update exitsting deployment',
+        value: 0,
+      },
+      {
+        name: 'Clear all and deploy as new',
+        value: 1,
+      },
+    ],
+    default: 0,
+  })
+
+  // if (!releaseVersion) {
+  //   releaseVersion = await readInput({
+  //     name: 'releaseVersion',
+  //     message: 'Enter the release version',
+  //   })
+  // }
+
+  // if (!releaseNote) {
+  //   releaseNote = await readInput({
+  //     name: 'releaseNote',
+  //     message: 'Enter the release note',
+  //   })
+  // }
+
+  try {
+    spinnies.add('dep', { text: 'Preparing to deploying' })
+
+    // Check if app and env exist in server
+    await checkAppEnvExist(appData, deployId)
+
+    const viewUpdatedAppData = await viewsDeploy({
+      appData,
+      deployId,
+      deployType,
+      releaseVersion,
+      releaseNote,
+    })
+
+    const functionsUpdatedAppData = await functionsDeploy({
+      appData: viewUpdatedAppData,
+      deployId,
+      deployType,
+      releaseVersion,
+      releaseNote,
+    })
+
+    // Create deploy history
+    await createDeployHistory({ deployId, releaseNote, tags: '' })
+
+    // Remove deployed
+    const updateEnv = Object.entries(functionsUpdatedAppData.environments).reduce((acc, [envName, envData]) => {
+      const envUpdate = { ...envData }
+      if (envUpdate.uploads?.[deployId]) {
+        delete envUpdate.uploads?.[deployId]
+      }
+      acc[envName] = envUpdate
+      return acc
+    }, {})
+
+    deployConfigManager.upsertDeployConfig = {
+      data: {
+        ...functionsUpdatedAppData,
+        environments: updateEnv,
+      },
+    }
+
+    spinnies.succeed('dep', { text: 'Deployed successfully' })
+  } catch (err) {
+    console.error(err)
+    const errMsg = `Deployment failed ${err.message}`
+    spinnies.fail('dep', { text: errMsg })
+  }
+}
+
+module.exports = abPremDeploy

--- a/subcommands/deploy/index.js
+++ b/subcommands/deploy/index.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const chalk = require('chalk')
+const { readInput } = require('../../utils/questionPrompts')
+const deployConfigManager = require('./manager')
+const abPremDeploy = require('./abPrem')
+const onPremDeploy = require('./onPrem')
+
+const deploy = async (options) => {
+  await deployConfigManager.init()
+
+  const appData = deployConfigManager.deployAppConfig
+
+  if (!appData?.app_id) {
+    console.log(chalk.red(`Deploy app does not exist. Please create-app and try again\n`))
+    process.exit(1)
+  }
+
+  const deployMethodType = await readInput({
+    type: 'list',
+    name: 'deployId',
+    message: 'Select the deployment server',
+    choices: [
+      { name: 'On-Premise', value: 0 },
+      { name: 'Appblocks-Premise (coming soon)', value: 1, disabled: true },
+    ],
+    default: 0,
+  })
+
+  if (deployMethodType === 0) {
+    await onPremDeploy({ argOpitons: options, appData, deployConfigManager })
+  } else {
+    await abPremDeploy({ argOpitons: options, appData, deployConfigManager })
+  }
+}
+
+module.exports = deploy

--- a/subcommands/deploy/manager.js
+++ b/subcommands/deploy/manager.js
@@ -1,0 +1,178 @@
+const { readFileSync, writeFileSync, existsSync, mkdirSync } = require('fs')
+const { EventEmitter } = require('events')
+const path = require('path')
+const { getOnPremConfigDetails } = require('./onPrem/util')
+const { isEmptyObject } = require('../../utils')
+
+/**
+ * DeployblockConfigManager
+ */
+
+class DeployblockConfigManager {
+  constructor() {
+    // eslint-disable-next-line no-bitwise
+    this.configName = 'app.config.json'
+    this.config = {}
+    this.cwd = '.'
+
+    this.onPremDeployContentBackupFolder = '.deploy/on_prem'
+    this.onPremDeployConfigFile = 'deploy.config.json'
+    this.onPremDeployedContentFile = '.deployed.config.json'
+
+    this.events = new EventEmitter()
+    this.events.on('write', (options) => this._write(options))
+
+    // this.init()
+  }
+
+  async syncOnPremDeploymentConfig(options) {
+    let onPremDeployConfig = await this.readOnPremDeployConfig
+    if (!isEmptyObject(onPremDeployConfig)) return onPremDeployConfig
+
+    onPremDeployConfig = await getOnPremConfigDetails(options)
+    this.writeOnPremDeployConfig({
+      [onPremDeployConfig.name]: onPremDeployConfig,
+    })
+
+    return { [onPremDeployConfig.name]: onPremDeployConfig }
+  }
+
+  async createOnPremDeploymentConfig(options) {
+    const onPremDeployConfig = await getOnPremConfigDetails(options)
+    this.writeOnPremDeployConfig({
+      ...this.onPremDeployConfig,
+      [onPremDeployConfig.name]: onPremDeployConfig,
+    })
+    return onPremDeployConfig
+  }
+
+  get deployAppConfig() {
+    if (this.config) return this.config
+    return null
+  }
+
+  get readOnPremDeployConfig() {
+    if (!isEmptyObject(this.onPremDeployConfig)) return this.onPremDeployConfig
+
+    const filePath = path.resolve(this.cwd, this.onPremDeployConfigFile)
+    if (!existsSync(filePath)) return {}
+    this.onPremDeployConfig = JSON.parse(readFileSync(filePath))
+
+    return this.onPremDeployConfig
+  }
+
+  writeOnPremDeployConfig(config) {
+    this.onPremDeployConfig = config
+    this.events.emit('write', { filePath: this.onPremDeployConfigFile, data: config })
+  }
+
+  get readOnPremDeployedConfig() {
+    if (!isEmptyObject(this.onPremDeployedConfig)) return this.onPremDeployedConfig
+
+    const filePath = path.resolve(this.cwd, this.onPremDeployedContentFile)
+    if (!existsSync(filePath)) return {}
+    this.onPremDeployedConfig = JSON.parse(readFileSync(filePath))
+
+    return this.onPremDeployedConfig
+  }
+
+  writeOnPremDeployedConfig({ config, name }) {
+    if (isEmptyObject(this.onPremDeployedConfig)) this.onPremDeployedConfig = this.readOnPremDeployedConfig
+
+    if (!name) return
+
+    this.onPremDeployedConfig = {
+      ...this.onPremDeployedConfig,
+      [name]: config,
+    }
+
+    this.events.emit('write', { filePath: this.onPremDeployedContentFile, data: this.onPremDeployedConfig })
+  }
+
+  get uiBlocks() {
+    const filter = (block) => ['ui-container', 'ui-elements'].includes(block.meta.type)
+    return this.getDependencies(false, filter)
+  }
+
+  get allBlockNames() {
+    const picker = (block) => block.meta.name
+    return this.getDependencies(false, null, picker)
+  }
+
+  getOnPremDeployContentBackupFolder(options) {
+    const { suffix } = options
+    let folderPath = path.resolve(this.cwd, this.onPremDeployContentBackupFolder)
+    if (suffix) folderPath = path.join(folderPath, suffix)
+    if (!existsSync(folderPath)) mkdirSync(folderPath, { recursive: true })
+    return folderPath
+  }
+
+  get env() {
+    if (this.config.env) return this.config.env
+    return null
+  }
+
+  set env(envObj) {
+    if (typeof envObj === 'object') this.config.env = { ...envObj }
+    else {
+      throw new TypeError(`Expected env to be an Object, received env is of type ${typeof envObj}`)
+    }
+  }
+
+  set createDeployConfig(data) {
+    try {
+      this.config = data
+      this.events.emit('write')
+    } catch (error) {
+      console.log('Error creating app')
+    }
+  }
+
+  init(cwd, configName) {
+    if (Object.keys(this.config)?.length) return
+
+    this.configName = configName || this.configName
+    this.cwd = cwd || '.'
+
+    try {
+      this.readDeployAppConfig()
+    } catch (err) {
+      console.log(err.message)
+      process.exit(1)
+    }
+  }
+
+  set upsertDeployConfig({ name, data }) {
+    if (!name) this.config = data
+    else this.config = { ...this.config, [name]: data }
+    this.events.emit('write')
+  }
+
+  readDeployAppConfig() {
+    try {
+      // console.log(`Trying to read config file from ${path.resolve(this.cwd)}`)
+      this.config = JSON.parse(readFileSync(path.resolve(this.cwd, this.configName)))
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        if (!existsSync(path.resolve(this.cwd, 'block.config.json'))) {
+          throw new Error(`Please init block or run the command in root folder of your app `)
+        }
+      }
+      this.events.emit('write')
+    }
+  }
+
+  _write(options) {
+    try {
+      const { filePath, data } = options || {}
+      const filePathValue = filePath || this.configName
+      const saveValue = data || this.config
+      writeFileSync(path.resolve(this.cwd, filePathValue), JSON.stringify(saveValue, null, 2))
+    } catch (err) {
+      console.log('Error creating app.config.json')
+    }
+  }
+}
+
+const deployblockConfigManager = new DeployblockConfigManager()
+module.exports = deployblockConfigManager

--- a/subcommands/deploy/onPrem/awsFargate/index.js
+++ b/subcommands/deploy/onPrem/awsFargate/index.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+/* eslint-disable prefer-const */
+const { ecsHandler } = require('../../../../utils/aws/ecs')
+const { elbHandler } = require('../../../../utils/aws/elb')
+const { aasHandler } = require('../../../../utils/aws/aas')
+const { spinnies } = require('../../../../loader')
+
+const awsFargateDeploy = async ({ appData, envData, deployConfigManager, config }) => {
+  const deployedData = config.deployed
+
+  try {
+    const { app_id: appId, app_name: appName } = appData
+    const { environment_id: envId, environment_name: envName } = envData
+
+    // const { autoScaleAllowed } = awsHandler.getAWSFargateDeploymentConfig
+    const fargateDeploymentDNS = []
+
+    const containerExitingData = deployedData.aws_ecr
+    const { repositoryUri, repositoryName, port } = containerExitingData
+    const name = repositoryName
+    const deploymentName = config.name
+
+    spinnies.add(`fargateDep`, { text: `Setting up deployment for ${deploymentName}` })
+    let containerData = { ...containerExitingData, container_name: name, app_id: appId, environment_id: envId }
+
+    if (!repositoryUri || !repositoryName) return
+
+    const fargateConfig = config.aws_fargate
+    const options = { appId, appName, envId, envName, containerName: name, containerData, fargateConfig }
+
+    let {
+      clusterArn,
+      loadBalancerArn,
+      targetGroupArn,
+      taskDefinitionArn,
+      autoScalingPolicyArn,
+      autoScalableTargetResourceId,
+      serviceArn,
+      serviceName,
+      clusterName,
+      listenerArn,
+    } = deployedData
+
+    let dnsName = deployedData.server_dns
+
+    if (!clusterArn) {
+      spinnies.update(`fargateDep`, { text: `Creating cluster for ${name}` })
+      const clusterData = await ecsHandler.createCluster(options)
+      clusterArn = clusterData.cluster.clusterArn
+      clusterName = clusterData.cluster.clusterName
+      deployedData.clusterArn = clusterArn
+      deployedData.clusterName = clusterName
+    }
+
+    if (!taskDefinitionArn) {
+      spinnies.update(`fargateDep`, { text: `Registering task definition for ${name}` })
+      const tdData = await ecsHandler.registerTaskDefinition({
+        ...options,
+        repositoryUri,
+        repositoryName,
+        port,
+      })
+      taskDefinitionArn = tdData.taskDefinition.taskDefinitionArn
+      deployedData.taskDefinitionArn = taskDefinitionArn
+    }
+
+    if (!targetGroupArn) {
+      spinnies.update(`fargateDep`, { text: `Creating target group for ${name}` })
+      const targetGroupData = await elbHandler.createTargetGroup({ ...options, port })
+      targetGroupArn = targetGroupData.TargetGroup.TargetGroupArn
+      deployedData.targetGroupArn = targetGroupArn
+    }
+
+    if (!loadBalancerArn) {
+      spinnies.update(`fargateDep`, { text: `Creating load balancer for ${name}` })
+      const lbData = await elbHandler.createLoadBalancer(options)
+      loadBalancerArn = lbData.LoadBalancer.LoadBalancerArn
+      dnsName = `http://${lbData.LoadBalancer.DNSName}`
+      deployedData.loadBalancerArn = loadBalancerArn
+      deployedData.server_dns = dnsName
+    }
+
+    if (!listenerArn) {
+      spinnies.update(`fargateDep`, { text: `Creating load balancer listener for ${name}` })
+      const { Listener } = await elbHandler.createLoadBalancerListener({
+        ...options,
+        targetGroupArn,
+        loadBalancerArn,
+        port,
+      })
+      deployedData.listenerArn = Listener.ListenerArn
+    }
+
+    const loadBalancers = [
+      {
+        targetGroupArn,
+        containerName: repositoryName,
+        containerPort: port,
+      },
+    ]
+
+    if (!serviceArn) {
+      spinnies.update(`fargateDep`, { text: `Creating service for ${name}` })
+      const serviceData = await ecsHandler.createService({
+        ...options,
+        clusterArn,
+        taskDefinitionArn,
+        loadBalancers,
+      })
+      serviceArn = serviceData.service.serviceArn
+      deployedData.serviceArn = serviceArn
+      serviceName = serviceData.service.serviceName
+      deployedData.serviceName = serviceName
+    } else {
+      spinnies.update(`fargateDep`, { text: `Updating service for ${name}` })
+      await ecsHandler.updateService({ clusterArn, serviceName, fargateConfig })
+    }
+
+    // if (autoScaleAllowed) {
+    if (!autoScalableTargetResourceId) {
+      spinnies.update(`fargateDep`, { text: `Registering scalable target for ${name}` })
+      const scalableTargetData = await aasHandler.registerScalableTarget({ clusterName, serviceName, fargateConfig })
+      deployedData.autoScalableTargetResourceId = scalableTargetData.ResourceId
+    }
+    if (!autoScalingPolicyArn) {
+      spinnies.update(`fargateDep`, { text: `Creating scaling policy for ${name}` })
+      const scalePolicyData = await aasHandler.putScalingPolicy({ clusterName, serviceName, fargateConfig })
+      deployedData.autoScalingPolicyArn = scalePolicyData.PolicyARN
+    }
+    // }
+
+    spinnies.update(`fargateDep`, { text: `Saving container data for ${name}` })
+
+    fargateDeploymentDNS.push({
+      name: deploymentName,
+      container: name,
+      load_balancer_dns: dnsName,
+    })
+
+    spinnies.succeed(`fargateDep`, {
+      text: `${name} container deployed successfully.\n  Visit ${dnsName} to access the container app. \n  (Note: It may take few minutes to be provisioned.)`,
+    })
+
+    const onPremEnvData = envData.on_premise || {}
+    const onPremBackendEnv = onPremEnvData.backend || {}
+    const existingFargateData = onPremBackendEnv?.aws_fargate || []
+    onPremBackendEnv.aws_fargate = [...existingFargateData, ...fargateDeploymentDNS]
+
+    const newEnvData = {
+      ...envData,
+      on_premise: {
+        ...onPremEnvData,
+        backend: onPremBackendEnv,
+      },
+    }
+
+    // eslint-disable-next-line no-param-reassign
+    deployConfigManager.upsertDeployConfig = {
+      name: 'environments',
+      data: {
+        ...appData.environments,
+        [envName]: newEnvData,
+      },
+    }
+    deployedData.newUploads = false
+    await deployConfigManager.writeOnPremDeployedConfig({ config: deployedData, name: config.name })
+  } catch (error) {
+    await deployConfigManager.writeOnPremDeployedConfig({ config: deployedData, name: config.name })
+    spinnies.add('fargateDep')
+    spinnies.fail('fargateDep', { text: `Error deploying: ${error.message}` })
+  }
+}
+
+module.exports = awsFargateDeploy

--- a/subcommands/deploy/onPrem/awsFargate/util.js
+++ b/subcommands/deploy/onPrem/awsFargate/util.js
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { spinnies } = require('../../../../loader')
+const { ec2Handler } = require('../../../../utils/aws/ec2')
+const { readInput } = require('../../../../utils/questionPrompts')
+
+const CPU_MEMORY_COMPINATIONS = [
+  {
+    cpu: '.25 vCPU',
+    memory: ['.5 GB', '1 GB', '2 GB'],
+  },
+  {
+    cpu: '.5 vCPU',
+    memory: Array.from({ length: 4 }, (_, i) => `${i + 1} GB`),
+  },
+  {
+    cpu: '1 vCPU',
+    memory: Array.from({ length: 7 }, (_, i) => `${i + 2} GB`),
+  },
+  {
+    cpu: '2 vCPU',
+    memory: Array.from({ length: 13 }, (_, i) => `${i + 4} GB`), // 4 GB - 16 GB (interval 1GB)
+  },
+  {
+    cpu: '4 vCPU',
+    memory: Array.from({ length: 23 }, (_, i) => `${i + 8} GB`), // 8 GB - 30 GB (interval 1GB)
+  },
+  {
+    cpu: '8 vCPU',
+    memory: Array.from({ length: 12 }, (_, i) => `${i * 4 + 16} GB`), // 16 GB - 60 GB (interval 4GB)
+  },
+]
+
+const getAWSFargateConfig = async () => {
+  spinnies.add('vpcGet', { text: 'Getting vpcs' })
+  const vpcs = await ec2Handler.describeVpcs()
+  spinnies.remove('vpcGet')
+  const vpcId = await readInput({
+    type: 'list',
+    name: 'vpcId',
+    message: 'Select the vpc to connect',
+    choices: vpcs.map((v) => ({ name: v.VpcId, value: v.VpcId })),
+    validate: (input) => {
+      if (!input) return `Invalid input`
+      return true
+    },
+  })
+
+  spinnies.add('subnets', { text: 'Getting subnets' })
+  const subnets = await ec2Handler.describeSubnets({ filters: [{ Name: 'vpc-id', Values: [vpcId] }] })
+  spinnies.remove('subnets')
+
+  const subnetIds = await readInput({
+    type: 'checkbox',
+    name: 'subnetIds',
+    message: 'Select the subnets',
+    choices: subnets.map((s) => ({ name: s.SubnetId, value: s.SubnetId })),
+    validate: (input) => {
+      if (!input) return `Invalid input`
+      if (input.length < 2) return `Min 2 subnets required`
+      return true
+    },
+  })
+
+  spinnies.add('sg', { text: 'Getting Security Groups' })
+  const securityGroupList = await ec2Handler.describeSecurityGroups({ filters: [{ Name: 'vpc-id', Values: [vpcId] }] })
+  spinnies.remove('sg')
+
+  const securityGroupIds = await readInput({
+    type: 'checkbox',
+    name: 'securityGroupIds',
+    message: 'Enter security group ',
+    choices: securityGroupList.map((sg) => ({ name: sg.GroupName, value: sg.GroupId })),
+    validate: (input) => {
+      if (!input || input?.length < 1) return `Invalid input`
+      return true
+    },
+  })
+
+  const cpu = await readInput({
+    type: 'list',
+    name: 'cpu',
+    message: 'Select the amount of CPU to reserve for your task',
+    choices: CPU_MEMORY_COMPINATIONS.map(({ cpu: c }) => c),
+    validate: (input) => {
+      if (!input || input?.length < 1) return `Invalid input`
+      return true
+    },
+  })
+
+  const memory = await readInput({
+    type: 'list',
+    name: 'memory',
+    message: 'Select the amount of memory to reserve for your task',
+    choices: CPU_MEMORY_COMPINATIONS.find(({ cpu: c }) => c === cpu)?.memory,
+    validate: (input) => {
+      if (!input || input?.length < 1) return `Invalid input`
+      return true
+    },
+  })
+
+  const autoScaleAllowed = true
+  // const autoScaleAllowed = await readInput({
+  //   type: 'confirm',
+  //   name: 'autoScaleAllowed',
+  //   message: 'Do you want to add auto scaling',
+  //   default: true,
+  // })
+
+  const cofigData = { vpcId, subnetIds, securityGroupIds, memory, cpu, autoScaleAllowed }
+
+  if (autoScaleAllowed) {
+    cofigData.minCapacity = await readInput({
+      type: 'number',
+      name: 'minCapacity',
+      message: 'Enter the minimum value that you plan to scale in to (min no of instances).',
+      validate: (input) => {
+        if (!input || !/[0-9]/.test(input)) return `Invalid input`
+        return true
+      },
+      default: 1,
+    })
+
+    cofigData.maxCapacity = await readInput({
+      type: 'number',
+      name: 'maxCapacity',
+      message: 'Enter the maximum value that you plan to scale out to (max no of instances).',
+      validate: (input) => {
+        if (!input || !/[0-9]/.test(input) || input < cofigData.minCapacity) return `Invalid input`
+        return true
+      },
+      default: 3,
+    })
+  }
+
+  cofigData.desiredCount = await readInput({
+    type: 'number',
+    name: 'desiredCount',
+    message:
+      'Enter the number of instantiations of the specified task definition to place and keep running on your cluster.',
+    validate: (input) => {
+      if (!input) return `Invalid input`
+      if (!/[0-9]/.test(input) || input < cofigData.minCapacity || input > cofigData.maxCapacity) {
+        return `Value should be in between min capacity and max capacity`
+      }
+      return true
+    },
+    default: 2,
+  })
+
+  return cofigData
+}
+
+module.exports = {
+  getAWSFargateConfig,
+}

--- a/subcommands/deploy/onPrem/awsStaticWeb/index.js
+++ b/subcommands/deploy/onPrem/awsStaticWeb/index.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { spinnies } = require('../../../../loader')
+const { s3Handler } = require('../../../../utils/aws/s3')
+
+const awsStaticWebDeploy = async (options) => {
+  try {
+    const { config, appData, envData, deployConfigManager } = options
+    const deployedData = config.deployed
+
+    spinnies.add(`s3Dep`, { text: `Deploying ${config.name} details` })
+    if (!deployedData.server_dns) {
+      const { bucket } = config.aws_s3
+      await s3Handler.putBucketPolicy({ bucket })
+      const { static_host } = await s3Handler.putBucketWebsite({ bucket })
+      deployedData.server_dns = static_host
+      deployedData.bucket = bucket
+
+      const onPremEnvData = envData.on_premise || {}
+      const onPremBackendEnv = onPremEnvData.frontend || {}
+      const existingS3Data = onPremBackendEnv?.aws_static_web_hosting || []
+      onPremBackendEnv.aws_static_web_hosting = [
+        ...existingS3Data,
+        {
+          name: config.name,
+          bucket,
+          static_host,
+        },
+      ]
+
+      const newEnvData = {
+        ...envData,
+        on_premise: {
+          ...onPremEnvData,
+          frontend: onPremBackendEnv,
+        },
+      }
+
+      deployConfigManager.upsertDeployConfig = {
+        name: 'environments',
+        data: {
+          ...appData.environments,
+          [envData.environment_name]: newEnvData,
+        },
+      }
+    }
+
+    deployedData.newUploads = false
+    await deployConfigManager.writeOnPremDeployedConfig({ config: deployedData, name: config.name })
+
+    spinnies.succeed(`s3Dep`, {
+      text: `${config.name} deployed successfully. Visit ${deployedData.server_dns} to access.`,
+    })
+  } catch (error) {
+    spinnies.add(`s3Dep`)
+    spinnies.succeed(`s3Dep`, { text: `Error: ${error.message || error}` })
+  }
+}
+
+module.exports = awsStaticWebDeploy

--- a/subcommands/deploy/onPrem/awsStaticWeb/util.js
+++ b/subcommands/deploy/onPrem/awsStaticWeb/util.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const getAWSStaticHostConfig = async () => ({})
+
+module.exports = {
+  getAWSStaticHostConfig,
+}

--- a/subcommands/deploy/onPrem/index.js
+++ b/subcommands/deploy/onPrem/index.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const { logFail } = require('../../../utils')
+const { awsHandler } = require('../../../utils/aws')
+const { readInput } = require('../../../utils/questionPrompts')
+const awsFargateDeploy = require('./awsFargate')
+const awsStaticWebDeploy = require('./awsStaticWeb')
+
+const onPremDeploy = async (options) => {
+  const { appData, deployConfigManager } = options
+
+  await awsHandler.syncAWSConfig()
+
+  const deployedData = deployConfigManager.readOnPremDeployedConfig
+
+  const choices = Object.values(deployedData)
+    .filter((d) => d.newUploads)
+    .map((d) => ({ name: d.name, value: d }))
+
+  if (!choices.length) {
+    logFail(`No uploads for deploy. Please upload and try again\n`)
+    process.exit(1)
+  }
+
+  const deployed = await readInput({
+    type: 'list',
+    name: 'config',
+    message: 'Select deployment configuration name to deploy',
+    choices,
+  })
+  const config = await deployConfigManager.readOnPremDeployConfig[deployed.name]
+  config.deployed = deployed
+
+  const envData = appData.environments[config.envName]
+  envData.environment_name = config.envName
+
+  if (!envData.environment_id) {
+    logFail(`No environment not exist with id ${config.environment_id}\n`)
+    process.exit(1)
+  }
+
+  if (!config) {
+    logFail(`Error getting configuration for ${deployed.name}\n`)
+    process.exit(1)
+  }
+
+  const { deployService } = config
+
+  switch (deployService) {
+    case 'aws_fargate':
+      await awsFargateDeploy({ ...options, envData, config })
+      break
+
+    case 'aws_static_web_hosting':
+      await awsStaticWebDeploy({ ...options, envData, config })
+      break
+
+    default:
+      logFail(`${deployService} deploy service not supported\n`)
+      process.exit(1)
+      break
+  }
+}
+
+module.exports = onPremDeploy

--- a/subcommands/deploy/onPrem/util.js
+++ b/subcommands/deploy/onPrem/util.js
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { domainRegex } = require('../../../utils')
+const { readInput } = require('../../../utils/questionPrompts')
+const { getAWSECRConfig } = require('../../upload/onPrem/awsECR/util')
+const { getAWSS3Config } = require('../../upload/onPrem/awsS3/util')
+const { getAWSFargateConfig } = require('./awsFargate/util')
+const { getAWSStaticHostConfig } = require('./awsStaticWeb/util')
+const { appConfig: abConfig } = require('../../../utils/appconfigStore')
+const { getBBConfig } = require('../../../utils/config-manager')
+
+const getDeploymentServiceChoices = (type) => {
+  switch (type) {
+    case 'view':
+      return [{ name: 'AWS STATIC WEB HOSTING', value: 'aws_static_web_hosting' }]
+    case 'function':
+      return [{ name: 'AWS FARGATE', value: 'aws_fargate' }]
+    default:
+      return []
+  }
+}
+
+const getUploadServiceChoices = (type) => {
+  switch (type) {
+    case 'view':
+      return [{ name: 'AWS S3', value: 'aws_s3' }]
+    case 'function':
+      return [{ name: 'AWS ECR', value: 'aws_ecr' }]
+    default:
+      return []
+  }
+}
+
+const getUploadServiceConfig = async (options) => {
+  switch (options.uploadService) {
+    case 'aws_s3':
+      return getAWSS3Config(options)
+    case 'aws_ecr':
+      return getAWSECRConfig(options)
+    default:
+      return {}
+  }
+}
+
+const getDeployServiceConfig = async (options) => {
+  switch (options.deployService) {
+    case 'aws_static_web_hosting':
+      return getAWSStaticHostConfig(options)
+    case 'aws_fargate':
+      return getAWSFargateConfig(options)
+    default:
+      return {}
+  }
+}
+
+const getOnPremConfigDetails = async (options) => {
+  await abConfig.init()
+
+  // eslint-disable-next-line prefer-const
+  let { opdName, upService, opdDomain, blocks, dpService, appData, blockType, envData, existingConfigNames } =
+    options || {}
+
+  const envName = envData.environment_name
+  const appName = appData.app_name
+
+  if (!blockType) {
+    blockType = await readInput({
+      type: 'list',
+      name: 'blockType',
+      message: 'Select the block type',
+      choices: [
+        { name: 'View', value: 'view' },
+        { name: 'Function', value: 'function' },
+      ],
+      default: 0,
+    })
+  }
+
+  if (!blocks) {
+    const { dependencies } = await getBBConfig()
+    const choices =
+      blockType === 'view'
+        ? Object.values(dependencies)
+            .filter((b) => ['ui-container', 'ui-elements'].includes(b.meta.type))
+            .map((b) => b.meta.name)
+        : Object.values(dependencies)
+            .filter((b) => ['function'].includes(b.meta.type))
+            .map((b) => b.meta.name)
+
+    blocks = await readInput({
+      type: 'checkbox',
+      name: 'blocks',
+      message: 'Select the blocks',
+      choices,
+      validate: (input) => {
+        if (!input) return `Invalid input`
+        return true
+      },
+      default: choices,
+    })
+  }
+
+  if (!upService) {
+    const choices = getUploadServiceChoices(blockType)
+    upService = await readInput({
+      type: 'list',
+      name: 'upService',
+      message: 'Select the upload service',
+      choices,
+      default: 'aws_s3',
+    })
+  }
+
+  if (!dpService) {
+    const choices = getDeploymentServiceChoices(blockType)
+    dpService = await readInput({
+      type: 'list',
+      name: 'dpService',
+      message: 'Select the deploy service',
+      choices,
+      default: 'aws_static_web_hosting',
+    })
+  }
+
+  if (!opdName) {
+    opdName = await readInput({
+      name: 'opdName',
+      message: 'Enter a name for deployment',
+      default: `${appName}_${envName}_${blockType}_${upService}_${dpService}`,
+      validate: (input) => {
+        if (!input || input.length < 3) return `Invalid input`
+        if (existingConfigNames?.includes[input]) return `Name already exists`
+        return true
+      },
+    })
+  }
+
+  if (!opdDomain) {
+    opdDomain = await readInput({
+      name: 'doamin',
+      message: `Enter domain name of ${blockType ? 'functions' : 'views'} deploy`,
+      validate: (input) => {
+        if (!input) return `Invalid input`
+        if (!domainRegex.test(input)) return `Invalid domain name`
+        return true
+      },
+    })
+  }
+
+  const configData = {
+    name: opdName,
+    uploadService: upService,
+    domain: opdDomain,
+    blockType,
+    appName,
+    deployService: dpService,
+    envName,
+    blocks,
+  }
+
+  console.log(`Reading configuration for ${upService}`)
+  const uploadServiceCofig = await getUploadServiceConfig({ serviceName: upService, ...configData })
+  console.log(`Reading configuration for ${dpService}`)
+  const deployServiceCofig = await getDeployServiceConfig({ serviceName: dpService, ...configData })
+
+  return {
+    ...configData,
+    [configData.uploadService]: uploadServiceCofig,
+    [configData.deployService]: deployServiceCofig,
+  }
+}
+
+module.exports = {
+  getDeploymentServiceChoices,
+  getOnPremConfigDetails,
+}

--- a/subcommands/deploy/util.js
+++ b/subcommands/deploy/util.js
@@ -1,0 +1,369 @@
+/* eslint-disable no-promise-executor-return */
+/* eslint-disable arrow-body-style */
+/* eslint-disable no-async-promise-executor */
+/* eslint-disable consistent-return */
+
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { readFileSync, rm } = require('fs')
+const path = require('path')
+const chalk = require('chalk')
+const { default: axios } = require('axios')
+const {
+  appRegistryCopyObject,
+  appRegistryCreateBucket,
+  appRegistryCreateHostDns,
+  appRegistryCreateVmInstance,
+  appRegistryAddVmEnvUser,
+  appRegistryDeployFunctions,
+  appRegistryCreateDiployHistory,
+  appRegistryCheckAppEnvExist,
+} = require('../../utils/api')
+const { getShieldHeader } = require('../../utils/getHeaders')
+const { spinnies } = require('../../loader')
+const deployblockConfigManager = require('./manager')
+const { getBlockDetails } = require('../../utils/registryUtils')
+
+const getBlockConfig = () => {
+  // if no appblock config file found, throw
+
+  try {
+    return JSON.parse(readFileSync('block.config.json'))
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.log(chalk.red(`block.config.json missing`))
+      process.exit(1)
+    }
+    console.log('Something went wrong\n')
+    console.log(err)
+    process.exit(1)
+  }
+}
+
+const getBlockId = async (blockName) => {
+  try {
+    const resp = await getBlockDetails(blockName)
+    if (resp.status === 204) throw new Error(`${blockName} doesn't exists in block repository`).message
+
+    const { data } = resp
+    if (data.err) {
+      throw new Error('Something went wrong from our side\n', data.msg).message
+    }
+
+    return data.data.ID
+  } catch (err) {
+    console.log(`Something went wrong while getting details of block:${blockName} -- ${err} `)
+    process.exit(1)
+  }
+}
+
+const getEnvDatas = (appData, deployId, deployType) => {
+  return new Promise(async (resolve) => {
+    const [envName, envData] = Object.entries(appData.environments).find(([, edata]) => edata.uploads?.[deployId]) || []
+
+    if (!envData) {
+      console.log(chalk.red(`\nEnvironment not exist. Please create-env and try again`))
+      process.exit(1)
+    }
+
+    // Only FE view modules
+    const keys = envData.uploads[deployId].reduce((acc, object_key) => {
+      if (object_key.includes(deployType)) acc.push(object_key)
+      return acc
+    }, [])
+
+    resolve({ appData, envData, envName, keys })
+  })
+}
+
+const viewsDeploy = (options) => {
+  return new Promise(async (resolve, reject) => {
+    const { appData, deployId } = options
+
+    try {
+      const { envData, envName, keys } = await getEnvDatas(appData, deployId, 'view')
+
+      // Return if nothing to deploy for view
+      if (!keys.length) return resolve(appData)
+
+      let updateAppData = { ...appData }
+
+      spinnies.add('dep', { text: `Deploying views to ${envName}` })
+
+      const { bucket = envData.frontend_url, host = false, environment_id, frontend_url } = envData
+
+      if (!frontend_url) {
+        console.log(chalk.red(`\nIssue with frontend_url. Please check the environment`))
+        process.exit(1)
+      }
+
+      if (!host) {
+        await axios.post(
+          appRegistryCreateBucket,
+          {
+            app_name: appData.app_name,
+            environment_name: envName,
+            environment_id,
+            domain_url: bucket,
+          },
+          {
+            headers: getShieldHeader(),
+          }
+        )
+
+        await axios.post(
+          appRegistryCreateHostDns,
+          {
+            app_id: appData.app_id,
+            environment_id,
+            domain_url: frontend_url,
+            static_url: true,
+          },
+          {
+            headers: getShieldHeader(),
+          }
+        )
+
+        updateAppData = {
+          ...appData,
+          environments: {
+            ...appData.environments,
+            [envName]: {
+              ...appData.environments[envName],
+              bucket,
+              host: true,
+            },
+          },
+        }
+      }
+
+      await axios.post(
+        appRegistryCopyObject,
+        { keys, bucket: frontend_url, deploy_id: deployId },
+        { headers: getShieldHeader() }
+      )
+
+      resolve(updateAppData)
+
+      console.log(chalk.green(`Views will be live at https://${frontend_url} in few minutes`))
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+const functionsDeploy = (options) => {
+  return new Promise(async (resolve, reject) => {
+    const { appData, deployId, deployType } = options
+
+    try {
+      const { envData, envName, keys } = await getEnvDatas(appData, deployId, 'functions')
+
+      // Return if nothing to deploy for functions
+      if (!keys.length) return resolve(appData)
+
+      spinnies.add('dep', { text: `Deploying functions to ${envName}` })
+
+      let { vmInstance = false } = appData
+      const { vmUser, environment_id, backend_url } = envData
+      const updateAppData = { ...appData }
+
+      if (!backend_url) {
+        console.log(chalk.red(`\nIssue with backend_url. Please check the environment`))
+        process.exit(1)
+      }
+
+      let vmExist = vmInstance
+      let vmUserExist = vmUser
+
+      if (!vmInstance) {
+        const res = await axios.post(
+          appRegistryCreateVmInstance,
+          {
+            app_name: appData.app_name,
+            environment_name: envName,
+            app_id: appData.app_id,
+            environment_id,
+            backend_url,
+            deploy_type: deployType,
+            deploy_id: deployId,
+            lang: 'js',
+          },
+          {
+            headers: getShieldHeader(),
+          }
+        )
+        vmExist = res.data.exist
+
+        vmInstance = true
+        updateAppData.environments[envName].vmUser = true
+      }
+
+      if (!vmUser && vmExist) {
+        const vmUserRes = await axios.post(
+          appRegistryAddVmEnvUser,
+          {
+            app_id: appData.app_id,
+            environment_name: envName,
+            environment_id,
+            deploy_type: deployType,
+            deploy_id: deployId,
+            lang: 'js',
+          },
+          {
+            headers: getShieldHeader(),
+          }
+        )
+
+        vmUserExist = vmUserRes.data.exist
+
+        updateAppData.environments[envName].vmUser = true
+      }
+
+      if (vmExist && vmUserExist) {
+        await axios.post(
+          appRegistryDeployFunctions,
+          {
+            app_id: appData.app_id,
+            environment_name: envName,
+            environment_id,
+            deploy_type: deployType,
+            deploy_id: deployId,
+            lang: 'js',
+          },
+          {
+            headers: getShieldHeader(),
+          }
+        )
+      }
+
+      console.log(chalk.green(`Functions will be live at https://${backend_url} in few minutes`))
+
+      resolve({ ...updateAppData, vmInstance })
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+const createDeployHistory = (options) => {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const { deployId, releaseNote, tags } = options
+
+      await axios.post(
+        appRegistryCreateDiployHistory,
+        {
+          deploy_id: deployId,
+          release_notes: releaseNote,
+          tags,
+        },
+        {
+          headers: getShieldHeader(),
+        }
+      )
+      resolve(true)
+    } catch (error) {
+      reject(error)
+    }
+  })
+}
+
+const checkAppEnvExist = (appData, deployId) => {
+  return new Promise(async (resolve) => {
+    try {
+      spinnies.add('dep', { text: `Checking app details` })
+      const envData = Object.values(appData.environments).find((env) => env.uploads?.[deployId])
+      const {
+        data: { data },
+      } = await axios.post(
+        `${appRegistryCheckAppEnvExist}`,
+        {
+          app_id: appData.app_id,
+          environment_id: envData.environment_id,
+        },
+        {
+          headers: getShieldHeader(),
+        }
+      )
+
+      const resData = data
+
+      if (!resData.app_exist || !resData.env_exist) {
+        spinnies.fail('dep', { text: ` ${!resData.app_exist ? 'App' : 'Environment'} does not exist` })
+        const dpath = path.resolve(deployblockConfigManager.configName)
+        rm(dpath, () => {
+          process.exit(1)
+        })
+      }
+      resolve(true)
+    } catch (error) {
+      spinnies.fail('dep', { text: 'Error getting app data' })
+      resolve(true)
+      process.exit(1)
+    }
+  })
+}
+
+module.exports = {
+  viewsDeploy,
+  getEnvDatas,
+  createDeployHistory,
+  functionsDeploy,
+  getBlockConfig,
+  getBlockId,
+  checkAppEnvExist,
+}
+
+// if (envData.distribution) {
+//   console.log('Host update')
+//   return
+// }
+
+// const createDistributionRes = await axios.post(
+//   appRegistryCreateDistribution,
+//   {
+//     app_id: appData.app_id,
+//     environment_id: envData.environment_id,
+//   },
+//   {
+//     headers: getShieldHeader(),
+//   }
+// )
+// console.log(
+//   '🚀 ~ file: deployUtil.js ~ line 193 ~ awsDeploy ~ createDistributionRes',
+//   createDistributionRes.data
+// )
+
+// const setEnvZip = async (enviroment, zipFolder) => {
+//   // if no appblock config file found, throw
+//   try {
+//     const envFiles = {
+//       dev: ['.env.functions', '.env.view'],
+//       stag: ['.env.functions.stag', '.env.view.stag'],
+//       prod: ['.env.functions.prod', '.env.view.prod'],
+//     }
+
+//     const envFile = envFiles[enviroment]
+//     const zipEnvs = envFile.forEach((acc, f) => {
+//       if (!existsSync(`./${f}`)) {
+//         console.log(chalk.red(`\nEnviroment ${f} file not found !!!`))
+//         process.exit(1)
+//       }
+//       return `${acc}./${f} `
+//     }, '')
+//     const zipFile = `${zipFolder}/env.zip`
+//     childProcess.execSync(`zip -r ${zipFile} ${zipEnvs}`)
+
+//     return zipFile
+//   } catch (err) {
+//     console.log('Something went wrong\n')
+//     console.log(err)
+//     process.exit(1)
+//   }
+// }

--- a/subcommands/getBlockUpdate/index.js
+++ b/subcommands/getBlockUpdate/index.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { spinnies } = require('../../loader')
+const { appConfig } = require('../../utils/appconfigStore')
+const { getBlockDetails } = require('../../utils/registryUtils')
+const { pullBlockUpdate } = require('./util')
+
+const getBlockUpdate = async (componentName, options, { cwd = '.' }) => {
+  spinnies.add('blockExistsCheck', { text: 'Getting block details ' })
+
+  try {
+    const {
+      status,
+      data: { err, msg, data: blockDetails },
+    } = await getBlockDetails(componentName)
+
+    if (status === 204) {
+      spinnies.fail('blockExistsCheck', { text: `${componentName} doesn't exists in block repository` })
+      return
+    }
+    if (err) {
+      throw new Error(msg).message
+    }
+
+    await appConfig.init(cwd, null, 'get-update')
+
+    spinnies.remove('blockExistsCheck')
+
+    if (blockDetails.BlockType === 1) {
+      throw new Error('Appblock update is not supported')
+    }
+
+    if (!appConfig.isInAppblockContext) {
+      throw new Error('Need to be inside an Appblock to pull other blocks')
+    }
+
+    await pullBlockUpdate({ blockDetails, cwd, appConfig })
+  } catch (err) {
+    spinnies.add('blockExistsCheck')
+    let message = err.message || err
+
+    if (err.response?.status === 401 || err.response?.status === 403) {
+      message = `Access denied for block ${componentName}`
+    }
+
+    spinnies.fail('blockExistsCheck', { text: message })
+    spinnies.remove('blockExistsCheck')
+  }
+}
+
+module.exports = getBlockUpdate

--- a/subcommands/getBlockUpdate/util.js
+++ b/subcommands/getBlockUpdate/util.js
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const path = require('path')
+const chalk = require('chalk')
+const { mkdirSync, existsSync, rm } = require('fs')
+
+const { spinnies } = require('../../loader')
+const { getBlockPersmissionsApi, trackBlockUpdatePull, listUnpulledBlockBersions } = require('../../utils/api')
+const { getBlockMetaData, getAllBlockVersions } = require('../../utils/registryUtils')
+const { post } = require('../../utils/axios')
+const { feedback } = require('../../utils/cli-feedback')
+const { pullSourceCodeFromAppblock } = require('../pull/sourceCodeUtil')
+const { configstore } = require('../../configstore')
+const { checkIsBlockAppAssinged } = require('../pull/purchasedPull')
+const { readInput } = require('../../utils/questionPrompts')
+
+const pullBlockUpdate = async (options) => {
+  let blockFolderPath
+  try {
+    const { blockDetails, cwd, appConfig } = options
+    // get the version id of the latest verion of parent
+    spinnies.add('pbu', { text: 'Getting block meta data ' })
+    const c = await getBlockMetaData(blockDetails.ID)
+    spinnies.remove('pbu')
+    if (c.data.err) throw new Error(c.data.msg)
+
+    const bmd = c.data.data
+
+    spinnies.add('pbu', { text: 'Checking block permission ' })
+    const { data: pData, error: pErr } = await post(getBlockPersmissionsApi, {
+      block_id: blockDetails.ID,
+    })
+    spinnies.remove('pbu')
+    if (pErr) throw pErr
+    const bpd = pData.data
+
+    const blockMetatData = { ...bmd, ...blockDetails, ...bpd }
+
+    const {
+      has_pull_access: hasPullBlockAccess,
+      block_visibility: blockVisiblity,
+      is_purchased_variant: isPurcahsedVariant,
+    } = blockMetatData
+
+    if (!hasPullBlockAccess && blockVisiblity !== 4) {
+      feedback({ type: 'info', message: `Pull access denied for block ${blockMetatData.BlockName}` })
+      return
+    }
+
+    let pullUpdateBlockId = blockMetatData.ID
+    let appData
+    let pullableBlockVersions = []
+
+    if (isPurcahsedVariant) {
+      // purchased block
+      pullUpdateBlockId = blockMetatData.purchased_parent_block_id
+
+      spinnies.add('pbu', { text: 'Getting parent block meta data ' })
+      const parentBlockRes = await getBlockMetaData(blockMetatData.purchased_parent_block_id)
+      spinnies.remove('pbu')
+      if (parentBlockRes.data.err) throw new Error(parentBlockRes.data.msg)
+      const pbmd = parentBlockRes.data.data
+
+      blockMetatData.parentBlockName = pbmd.block_name
+
+      const checkData = await checkIsBlockAppAssinged({ metaData: blockMetatData })
+      if (!checkData.exist) {
+        throw new Error(chalk.red(`Block is not assigned with ${checkData.app_name} \n`))
+      }
+      appData = checkData.appData
+
+      spinnies.add('pbu', { text: 'Getting latest block version ' })
+      const { data, error: luErr } = await post(listUnpulledBlockBersions, {
+        app_id: appData.app_id,
+        block_id: pullUpdateBlockId,
+      })
+      spinnies.remove('pbu')
+
+      if (luErr) throw luErr
+
+      pullableBlockVersions = data.data
+
+      if (!pullableBlockVersions?.length) {
+        throw new Error('No latest version found for the block to pull')
+      }
+    } else {
+      // free block
+      const appBlockConfigData = appConfig.appConfig
+      const blockConfigData = appBlockConfigData.dependencies[blockDetails.BlockName]
+
+      spinnies.add('pbu', { text: 'Getting block version ' })
+      const versionOf = blockConfigData.parent ? blockConfigData.parent.block_id : blockDetails.ID
+      const bv = await getAllBlockVersions(versionOf, { status: [4] })
+      spinnies.remove('pbu')
+
+      if (bv.data.err) throw new Error(bv.data.msg)
+
+      if (bv.status === 204) {
+        throw new Error('No version found for the block to pull')
+      }
+
+      pullableBlockVersions = bv.data.data
+
+      if (!pullableBlockVersions?.length) {
+        throw new Error('No version found for the block to pull')
+      }
+    }
+
+    const pullVersion = await readInput({
+      type: 'list',
+      name: 'pullVersion',
+      message: 'Select a version to update',
+      validate: (input) => {
+        if (!input) return `Please select a version`
+        return true
+      },
+      choices: pullableBlockVersions.map((d) => {
+        const data = {
+          version_number: isPurcahsedVariant ? d.block_version_number : d.version_number,
+          id: isPurcahsedVariant ? d.block_version_id : d.id,
+        }
+        return { name: data.version_number, value: data }
+      }),
+    })
+    blockMetatData.version_id = pullVersion?.id
+    blockMetatData.version_number = pullVersion?.version_number
+
+    if (!blockMetatData.version_id) {
+      throw new Error('Error getting version data')
+    }
+
+    const pulledFolderName = isPurcahsedVariant
+      ? `${blockMetatData.parentBlockName}@${blockMetatData.version_number}`
+      : `${blockMetatData.BlockName}@${blockMetatData.version_number}`
+    const blockUpdatesFolder = '_block_updates'
+
+    blockFolderPath = path.resolve(cwd, blockUpdatesFolder, pulledFolderName)
+
+    if (!existsSync(blockFolderPath)) mkdirSync(blockFolderPath, { recursive: true })
+
+    const pullOptions = { blockFolderPath, metaData: blockMetatData, blockId: blockMetatData.ID }
+
+    if (isPurcahsedVariant) {
+      pullOptions.blockId = blockMetatData.purchased_parent_block_id
+      pullOptions.variantBlockId = blockMetatData.ID
+      pullOptions.appId = appData.app_id
+      pullOptions.spaceId = configstore.get('currentSpaceId')
+    }
+
+    spinnies.add('pbu', { text: `Pulling block source code for version ${blockMetatData.version_number}` })
+    await pullSourceCodeFromAppblock(pullOptions)
+    spinnies.succeed('pbu', {
+      text: `Block update pulled successfully to ${blockUpdatesFolder}/${pulledFolderName} folder`,
+    })
+
+    if (isPurcahsedVariant) {
+      // update
+      const { error } = await post(trackBlockUpdatePull, {
+        block_id: blockMetatData.purchased_parent_block_id,
+        block_version_id: blockMetatData.version_id,
+        app_id: pullOptions.appId,
+      })
+
+      if (error) throw error
+    }
+  } catch (error) {
+    spinnies.add('pbu')
+    spinnies.fail('pbu', { text: error.response?.data?.msg || error.message || `Error pulling block update` })
+    spinnies.remove('pbu')
+
+    if (existsSync(blockFolderPath)) rm(blockFolderPath, { recursive: true })
+  }
+}
+
+module.exports = { pullBlockUpdate }

--- a/subcommands/provisionApp.js
+++ b/subcommands/provisionApp.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable camelcase */
+const { default: axios } = require('axios')
+const { appRegistryProvisionApp } = require('../utils/api')
+const { getShieldHeader } = require('../utils/getHeaders')
+const deployConfig = require('./deploy/manager')
+const { spinnies } = require('../loader')
+
+const provisionApp = async (appId) => {
+  deployConfig.init()
+  const appConfig = await deployConfig.deployAppConfig
+
+  if (appConfig?.app_id) {
+    console.log(`${appConfig.app_name} app already exist`)
+    process.exit(1)
+  }
+
+  try {
+    spinnies.add('pa', { text: 'Provisioning app ' })
+    const registerAppRes = await axios.post(
+      appRegistryProvisionApp,
+      { app_id: appId },
+      {
+        headers: getShieldHeader(),
+      }
+    )
+    console.log('data - ', registerAppRes.data)
+    const { data } = registerAppRes.config
+
+    const { app_details, env_details, vm_info_id } = data
+
+    let environments = {}
+
+    if (env_details?.length) {
+      environments = env_details.reduce((acc, env) => {
+        let backend_url
+        let frontend_url
+        env.domain.forEach((d) => {
+          if (d.type === 0) frontend_url = d.url
+          else backend_url = d.url
+        })
+
+        // const uploads = env.uploads.reduce((ac, u) => ({ ...ac, [u.id]: [] }), {})
+
+        return {
+          ...acc,
+          [env.name]: {
+            environment_id: env.id,
+            backend_url,
+            frontend_url,
+            // uploads,
+            vmUser: !!env.vmUser,
+          },
+        }
+      }, {})
+    }
+
+    const appData = {
+      ...app_details,
+      environments,
+      vmInstance: !!vm_info_id,
+    }
+    deployConfig.createDeployConfig = appData
+
+    spinnies.succeed('pa', { text: 'App provision success' })
+  } catch (err) {
+    spinnies.fail('pa', { text: err.message })
+    console.log(err.message || err)
+  }
+}
+
+module.exports = provisionApp

--- a/subcommands/publish/publish_bkup.js
+++ b/subcommands/publish/publish_bkup.js
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { default: axios } = require('axios')
+const { readFileSync } = require('fs')
+const semver = require('semver')
+const { configstore } = require('../../configstore')
+const { spinnies } = require('../../loader')
+const { appBlockAddVersion, createSourceCodeSignedUrl } = require('../../utils/api')
+const { appConfig } = require('../../utils/appconfigStore')
+const convertGitSshUrlToHttps = require('../../utils/convertGitUrl')
+const { getShieldHeader } = require('../../utils/getHeaders')
+const { isClean, getLatestVersion, addTag } = require('../../utils/gitCheckUtils')
+const { GitManager } = require('../../utils/gitmanager')
+const { readInput } = require('../../utils/questionPrompts')
+const { getAllBlockVersions } = require('../../utils/registryUtils')
+const { addDependencies, getDependencies } = require('./dependencyUtil')
+const { addLanguageVersions, getUpdatedLanguageVersionsData } = require('../languageVersion/util')
+const { createZip } = require('./util')
+
+const publish = async (blockname) => {
+  await appConfig.init(null, null)
+
+  if (appConfig.isInBlockContext && !appConfig.isInAppblockContext) {
+    // eslint-disable-next-line no-param-reassign
+    blockname = appConfig.allBlockNames.next().value
+  }
+
+  if (!appConfig.has(blockname)) {
+    console.log('Block not found!')
+    process.exit(1)
+  }
+
+  if (appConfig.isLive(blockname)) {
+    console.log('Block is live, please stop before operation')
+    process.exit(1)
+  }
+
+  // TODO - Check if there are any .sync files in the block and warn
+  const blockDetails = appConfig.getBlock(blockname)
+
+  try {
+    const latestVersion = getLatestVersion(blockDetails.directory)
+    if (latestVersion) console.log(`Last published version is ${latestVersion}`)
+
+    if (!isClean(blockDetails.directory)) {
+      console.log('Git directory is not clean, Please push before publish')
+      process.exit(1)
+    }
+
+    let latestVersionId
+
+    const blockId = await appConfig.getBlockId(blockname)
+    if (latestVersion) {
+      const { data } = await getAllBlockVersions(blockId)
+      latestVersionId = data.data?.[0].id
+    }
+
+    const version = await readInput({
+      name: 'version',
+      message: 'Enter the version',
+      validate: (ans) => {
+        if (semver.valid(ans)) {
+          if (latestVersion && semver.lt(semver.clean(ans), semver.clean(latestVersion))) {
+            return `Last published version is ${latestVersion}`
+          }
+          return true
+        }
+        return 'Invalid versioning'
+      },
+      default: latestVersion ? semver.inc(latestVersion, 'patch') : '0.0.1',
+    })
+
+    const message = await readInput({
+      name: 'tagMessage',
+      message: 'Enter a message to add to tag.(defaults to empty)',
+    })
+
+    // ========= languageVersion ========================
+    const { addLanguageVersionsList } = await getUpdatedLanguageVersionsData({
+      blockDetails,
+      blockId,
+      blockVersionId: latestVersionId,
+      blockVersion: version,
+      isNew: true,
+    })
+
+    // ========= dependencies ========================
+    // Check if the dependencies exit to link with block
+    const { dependencies, depExist } = await getDependencies({ blockDetails })
+    if (!depExist) {
+      const noDep = await readInput({
+        type: 'confirm',
+        name: 'noDep',
+        message: 'No package dependecies found to link with block. Do you want to continue ?',
+        default: true,
+      })
+
+      if (!noDep) process.exit(1)
+    }
+
+    spinnies.add('p1', { text: `Publishing new version ${version}` })
+
+    await addTag(blockDetails.directory, version, message)
+
+    const blockSource = blockDetails.meta.source
+    const prefersSsh = configstore.get('prefersSsh')
+    const repoUrl = prefersSsh ? blockSource.ssh : convertGitSshUrlToHttps(blockSource.ssh)
+    const Git = new GitManager(blockDetails.directory, 'Not very imp', repoUrl, prefersSsh)
+    // await pushTags(blockDetails.directory)
+    await Git.pushTags()
+
+    // Update source code to appblock cloud
+
+    spinnies.update('p1', { text: `Updating new version ${version} code` })
+
+    const zipFile = await createZip({ directory: blockDetails.directory, version })
+
+    const preSignedData = await axios.post(
+      createSourceCodeSignedUrl,
+      {
+        block_type: blockDetails.meta.type,
+        block_id: blockId,
+        block_name: blockDetails.meta.name,
+        block_version: version,
+      },
+      {
+        headers: getShieldHeader(),
+      }
+    )
+    const zipFileData = readFileSync(zipFile)
+    await axios.put(preSignedData.data.url, zipFileData, {
+      headers: {
+        'Content-Type': 'application/zip',
+      },
+    })
+
+    spinnies.update('p1', { text: `Registring new version ${version}` })
+
+    const resp = await axios.post(
+      appBlockAddVersion,
+      {
+        block_id: blockId,
+        version_no: semver.parse(version).version,
+        status: 1,
+        release_notes: message,
+        source_code_key: preSignedData.data.key,
+      },
+      { headers: getShieldHeader() }
+    )
+
+    const { data } = resp
+    if (data.err) {
+      throw new Error('Something went wrong from our side\n', data.msg).message
+    }
+
+    // Link languageVersion to block
+    spinnies.update('p1', { text: `Attaching languageVersion to block` })
+    await addLanguageVersions({ addLanguageVersionsList, blockId, blockVersionId: data.data.id })
+
+    // Link Dependecies to block
+    if (depExist) {
+      spinnies.update('p1', { text: `Attaching dependencies to block` })
+      await addDependencies({ dependencies, blockId, blockVersionId: data.data.id })
+    }
+
+    spinnies.succeed('p1', { text: 'Block published successfully' })
+  } catch (error) {
+    console.log(error)
+    spinnies.add('p1_error', { text: 'Error' })
+    spinnies.fail('p1_error', { text: error.message })
+    process.exit(1)
+  }
+}
+
+module.exports = publish

--- a/subcommands/pull/purchasedPull.js
+++ b/subcommands/pull/purchasedPull.js
@@ -1,0 +1,206 @@
+const chalk = require('chalk')
+const { readFileSync, writeFileSync } = require('fs')
+const path = require('path')
+
+const { configstore } = require('../../configstore')
+const { spinnies } = require('../../loader')
+const convertGitSshUrlToHttps = require('../../utils/convertGitUrl')
+const { createDirForType } = require('../../utils/fileAndFolderHelpers')
+const { confirmationPrompt, readInput } = require('../../utils/questionPrompts')
+const { pullSourceCodeFromAppblock } = require('./sourceCodeUtil')
+const createComponent = require('../../utils/createComponent')
+const { post } = require('../../utils/axios')
+const {
+  setInUseStatusForBlock,
+  checkBlockAssignedToApp,
+  assignBlockToApp,
+  updateBlockApi,
+  appBlockCheckBlockNameAvailability,
+  trackBlockUpdatePull,
+} = require('../../utils/api')
+const deployConfigManager = require('../deploy/manager')
+const { isValidBlockName } = require('../../utils/blocknameValidator')
+
+const checkIsBlockAppAssinged = async (options) => {
+  const { metaData, appData: ap } = options
+
+  let appData = ap
+
+  if (!ap) {
+    await deployConfigManager.init()
+
+    appData = deployConfigManager.deployAppConfig
+
+    if (!appData?.app_id) {
+      console.log(chalk.red(`App does not exist to pull into\n`))
+      process.exit(1)
+    }
+  }
+
+  spinnies.add('bp', { text: 'Checking if block is assinged with app' })
+  const { error: checkErr, data: checkD } = await post(checkBlockAssignedToApp, {
+    block_id: metaData.ID,
+    app_id: appData.app_id,
+    space_id: configstore.get('currentSpaceId'),
+  })
+  spinnies.remove('bp')
+  if (checkErr) throw checkErr
+
+  const data = checkD.data || {}
+  data.appName = appData.app_name
+  data.appData = appData
+
+  return data
+}
+
+/**
+ *
+ * @returns
+ */
+async function purchasedPull(options) {
+  const { metaData, appConfig, cwd } = options
+
+  // Pulling purchased block code
+  await deployConfigManager.init()
+
+  const appData = deployConfigManager.deployAppConfig
+
+  if (!appData?.app_id) {
+    console.log(chalk.red(`App does not exist to pull into\n`))
+    process.exit(1)
+  }
+
+  const checkData = await checkIsBlockAppAssinged({ metaData, appData })
+
+  if (!checkData.exist) {
+    if (checkData.can_assign) {
+      const assignAndContinue = await confirmationPrompt({
+        name: 'assignAndContinue',
+        message: `Block is not assigned. Do you wish to assign ${metaData.BlockName} block with ${appData.app_name}`,
+        default: false,
+      })
+
+      if (!assignAndContinue) throw new Error('Cancelled').message
+
+      spinnies.add('bp', { text: 'assinging block with app' })
+      const { error: assignErr } = await post(assignBlockToApp, {
+        block_id: metaData.ID,
+        app_id: appData.app_id,
+        space_id: configstore.get('currentSpaceId'),
+      })
+      spinnies.remove('bp')
+      if (assignErr) throw assignErr
+    } else {
+      console.log(chalk.red(`Block is not assigned with ${appData.app_name} \n`))
+      process.exit(1)
+    }
+  }
+
+  const availableName = await readInput({
+    name: 'blockName',
+    message: 'Enter the block name',
+    default: metaData.BlockName,
+    validate: async (ans) => {
+      if (!isValidBlockName(ans)) return 'Only snake case with numbers is valid'
+      try {
+        const res = await post(appBlockCheckBlockNameAvailability, {
+          block_name: ans,
+          block_id: metaData.block_id,
+        })
+
+        return !res.data.err
+      } catch (err) {
+        return 'Something went wrong in blocknameavailability check'
+      }
+    },
+  })
+
+  const clonePath = appConfig.isOutOfContext ? cwd : createDirForType(metaData.BlockType, cwd || '.')
+  const {
+    description,
+    // visibility,
+    sshUrl,
+    name: cdName,
+    blockFinalName: bfName,
+  } = await createComponent(availableName, false, clonePath, true)
+  const blockFinalName = bfName
+
+  const blockFolderPath = path.resolve(clonePath, blockFinalName)
+
+  spinnies.add('pab', { text: 'pulling block source code' })
+  await pullSourceCodeFromAppblock({
+    blockFolderPath,
+    metaData,
+    blockId: metaData.parent_id,
+    variantBlockId: metaData.ID,
+    appId: appData.app_id,
+    spaceId: configstore.get('currentSpaceId'),
+  })
+  spinnies.remove('pab')
+
+  if (!checkData.in_use) {
+    spinnies.add('pab', { text: 'updating block assinged' })
+    const { error } = await post(setInUseStatusForBlock, {
+      block_id: metaData.ID,
+      app_id: appData.app_id,
+      space_id: configstore.get('currentSpaceId'),
+    })
+    spinnies.remove('pab')
+    if (error) throw error
+  }
+
+  // update the block details
+  spinnies.add('pab', { text: 'updating block' })
+  const { error: upErr } = await post(updateBlockApi, {
+    block_id: metaData.ID,
+    block_name: blockFinalName,
+    block_short_name: blockFinalName,
+    description,
+    block_visibility: 2,
+    git_url: sshUrl,
+  })
+  spinnies.remove('pab')
+
+  if (upErr) throw upErr
+
+  // update track of pulled parent block
+  const { error } = await post(trackBlockUpdatePull, {
+    block_id: metaData.parent_id,
+    block_version_id: metaData.version_id,
+    app_id: appData.app_id,
+  })
+
+  if (error) throw error
+
+  const blockConfigPath = path.resolve(blockFolderPath, 'block.config.json')
+
+  let blockConfig
+  try {
+    blockConfig = JSON.parse(readFileSync(blockConfigPath))
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.log(chalk.dim('Pulled block has no config file, adding a new one'))
+
+      const isViewType = [2, 3].includes(metaData.BlockType)
+      blockConfig = {
+        type: metaData.BlockType,
+        language: isViewType ? 'js' : 'nodejs',
+        start: isViewType ? 'npx webpack-dev-server' : 'node index.js',
+        build: isViewType ? 'npx webpack' : '',
+        postPull: 'npm i',
+      }
+    }
+    console.log('err blockConfig', err)
+  }
+  blockConfig.name = blockFinalName
+  blockConfig.source = { https: convertGitSshUrlToHttps(sshUrl), ssh: sshUrl }
+  writeFileSync(blockConfigPath, JSON.stringify(blockConfig, null, 2))
+
+  return {
+    cloneDirName: cdName,
+    clonePath,
+    blockFinalName,
+  }
+}
+
+module.exports = { purchasedPull, checkIsBlockAppAssinged }

--- a/subcommands/pull/sourceCodeUtil.js
+++ b/subcommands/pull/sourceCodeUtil.js
@@ -24,7 +24,7 @@ const downloadSourceCode = async (url, blockFolderPath, blockName) => {
     }
 
     if (!data) {
-      reject(new Error('No block source code found'))
+      reject(new Error('No source code found'))
       return
     }
 
@@ -39,26 +39,27 @@ const downloadSourceCode = async (url, blockFolderPath, blockName) => {
   })
 }
 
-const getSignedSourceCodeUrl = async (metaData, appId, spaceId) => {
+const getSignedSourceCodeUrl = async ({ metaData, appId, spaceId, blockId, variantBlockId }) => {
   const postData = {
-    block_id: metaData.ID,
+    block_id: blockId,
     block_version_id: metaData.version_id,
   }
 
   if (appId) postData.app_id = appId
   if (spaceId) postData.space_id = spaceId
+  if (variantBlockId) postData.variant_block_id = variantBlockId
 
-  const { data, error } = await post(getSourceCodeSignedUrl)
+  const { data, error } = await post(getSourceCodeSignedUrl, postData)
 
-  if (error) throw new Error(error.response?.data?.msg || error.message)
+  if (error) throw error
 
   return data.data?.download_url
 }
 
 const pullSourceCodeFromAppblock = async (options) => {
-  const { blockFolderPath, metaData, appId, spaceId } = options || {}
+  const { blockFolderPath, metaData } = options || {}
 
-  const signedSourceCodeUrl = await getSignedSourceCodeUrl(metaData, appId, spaceId)
+  const signedSourceCodeUrl = await getSignedSourceCodeUrl(options)
   if (!signedSourceCodeUrl) throw new Error('Error getting source code from appblocks')
 
   await downloadSourceCode(signedSourceCodeUrl, blockFolderPath, metaData.BlockName)

--- a/subcommands/start.js
+++ b/subcommands/start.js
@@ -106,30 +106,31 @@ const start = async (blockname, { usePnpm }) => {
   const configData = appConfig.appConfig
   await setupEnv(configData)
 
-  if (!blockname) {
-    if ([...appConfig.allBlockNames].length <= 0) {
-      console.log('\nNo blocks to start!\n')
-      process.exit(1)
-    }
+  if (blockname && !appConfig.has(blockname)) {
+    console.log('Block not found')
+    return
+  }
 
-    let c = 0
-    // eslint-disable-next-line no-unused-vars
-    for (const _ of appConfig.nonLiveBlocks) {
-      c += 1
-    }
-    if (c === 0) {
-      console.log('\nAll blocks are already live!\n')
-    } else {
-      await startAllBlock()
-    }
-  } else {
-    if (!appConfig.has(blockname)) {
-      console.log('Block not found')
-      process.exit(1)
-    }
+  if (blockname) {
     const port = await getFreePorts(appConfig, blockname)
     await startBlock(blockname, port)
+    return
   }
+
+  // If no block name given
+
+  if ([...appConfig.allBlockNames].length <= 0) {
+    console.log('\nNo blocks to start!\n')
+    // process.exit(1)
+    return
+  }
+
+  if ([...appConfig.nonLiveBlocks].length === 0) {
+    console.log('\nAll blocks are already live!\n')
+    return
+  }
+
+  await startAllBlock()
 }
 
 async function startAllBlock() {

--- a/subcommands/stop.js
+++ b/subcommands/stop.js
@@ -9,6 +9,7 @@ const chalk = require('chalk')
 const { execSync } = require('child_process')
 const { stopEmulator } = require('../utils/emulator-manager')
 const { appConfig } = require('../utils/appconfigStore')
+const { sleep } = require('../utils')
 
 global.rootDir = process.cwd()
 
@@ -76,6 +77,7 @@ async function stopAllBlock(rootPath) {
 
   if ([...appConfig.liveBlocks].length === 0) {
     console.log('\nNo blocks are live!\n')
+    await sleep(2000) // to wait for any write opertaion to complete
     process.exit(1)
   }
 

--- a/subcommands/upload/abPrem/index.js
+++ b/subcommands/upload/abPrem/index.js
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable no-continue */
+
+const { rm } = require('fs')
+const path = require('path')
+const chalk = require('chalk')
+const { default: axios } = require('axios')
+const { getBlockId } = require('../../deploy/util')
+const { createZip, uploadToServer } = require('../util')
+const { appRegistryUploadBlockStatus } = require('../../../utils/api')
+const { getShieldHeader } = require('../../../utils/getHeaders')
+const deployConfig = require('../../deploy/manager')
+const { spinnies } = require('../../../loader')
+const { getPublishedVersion } = require('../../publish/util')
+const { logFail } = require('../../../utils')
+const { blockTypes } = require('../../../utils/blockTypes')
+const { getBBConfig } = require('../../../utils/config-manager')
+
+const abPremUpload = async ({ blockName, envData, appData, environment }) => {
+  const preparedForUpload = []
+  const uploadStatus = []
+  const { dependencies } = await getBBConfig()
+  const appId = appData.app_id
+  const blockTypeNames = blockTypes.map((v) => v[0])
+  const isBlockTypeWise = blockTypeNames.includes(blockName)
+
+  if (!blockName || isBlockTypeWise) {
+    /**
+     * UPLOAD ALL Block
+     */
+    spinnies.add('up', { text: `Uploading ${blockName || 'all'} block` })
+
+    for (const blockData of Object.values(dependencies)) {
+      const {
+        meta: { type, name },
+        directory,
+      } = blockData
+
+      if (isBlockTypeWise && blockName !== type) continue
+
+      spinnies.update('up', { text: `Preparing ${name} block to upload` })
+
+      const { success, latestVersion, msg } = getPublishedVersion(name, directory)
+
+      if (!success || !latestVersion) {
+        preparedForUpload.push({
+          success: false,
+          blockName: name,
+          latestVersion,
+          directory,
+          msg: latestVersion ? msg : `No published version found -> block ${name}`,
+        })
+        continue
+      }
+
+      const blockId = await getBlockId(name)
+
+      if (['ui-container', 'ui-elements'].includes(blockName || type)) {
+        const zipFile = await createZip({ directory, blockName: name, type })
+        preparedForUpload.push({
+          success: true,
+          blockType: type,
+          blockFolder: directory,
+          appId,
+          blockId,
+          zipFile,
+          blockName: name,
+          version: latestVersion,
+          environmentId: envData.environment_id,
+        })
+      } else {
+        const zipFile = await createZip({ directory, blockName: name })
+        preparedForUpload.push({
+          success: true,
+          blockType: type,
+          blockFolder: directory,
+          appId,
+          blockId,
+          zipFile,
+          blockName: name,
+          version: latestVersion,
+          environmentId: envData.environment_id,
+        })
+      }
+    }
+  } else {
+    /**
+     * UPLOAD SINGLE Block
+     */
+    spinnies.add('up', { text: `Upload ${blockName} block` })
+
+    if (!dependencies[blockName]) {
+      logFail(`\n${chalk.italic(blockName)} not found in dependencies`)
+      console.log(chalk.gray(`\nList of present blocks:\n${Object.keys(dependencies)}`))
+      console.log(chalk.gray(`\nList of blocke types:\n${blockTypeNames}`))
+      process.exit(1)
+    }
+
+    spinnies.update('up', { text: `Preparing ${blockName} block to upload` })
+
+    const blockId = await getBlockId(blockName)
+    const {
+      meta: { type },
+      directory,
+    } = dependencies[blockName]
+
+    const { success, latestVersion, msg } = getPublishedVersion(blockName, directory)
+    if (!success || !latestVersion) {
+      preparedForUpload.push({
+        success: false,
+        blockName,
+        latestVersion,
+        directory,
+        msg: latestVersion ? msg : `No published version found -> block ${blockName}`,
+      })
+    } else {
+      const zipFile = await createZip({ directory, blockName, type })
+      preparedForUpload.push({
+        success: true,
+        blockType: type,
+        blockFolder: directory,
+        appId,
+        blockId,
+        zipFile,
+        blockName,
+        version: latestVersion,
+        environmentId: envData.environment_id,
+      })
+    }
+  }
+
+  // Check if any block has error
+  if (preparedForUpload.some((v) => !v.success)) {
+    spinnies.fail('up', { text: 'Error preparing upload block' })
+    preparedForUpload.forEach((v) => {
+      if (v.msg) logFail(v.msg)
+    })
+    process.exit(1)
+  }
+
+  for (const bData of preparedForUpload) {
+    const uploadedRes = await uploadToServer({
+      ...bData,
+    })
+    uploadStatus.push({ ...uploadedRes, blockName: bData.blockName })
+  }
+
+  try {
+    // TODO handle unsuccessful blocks
+    if (uploadStatus.some((v) => v.success === false)) {
+      uploadStatus.forEach((v) => {
+        if (v.msg) logFail(v.msg)
+      })
+      spinnies.fail('up', { text: 'Error uploading block' })
+      return
+    }
+
+    spinnies.update('up', { text: `Setting uploaded blocks` })
+
+    const uploadedDataRes = await axios.post(
+      appRegistryUploadBlockStatus,
+      {
+        metadata: {},
+        request_blocks: uploadStatus,
+        environment_id: envData.environment_id,
+        tags: 'tag',
+      },
+      {
+        headers: getShieldHeader(),
+      }
+    )
+    const { deploy_id } = uploadedDataRes.data.data
+
+    const updateAppData = { ...appData }
+
+    const uploads = updateAppData.environments[environment].uploads || {}
+    uploads[deploy_id] = uploadStatus.map((up) => up.object_key)
+    updateAppData.environments[environment] = {
+      ...updateAppData.environments[environment],
+      uploads,
+    }
+
+    deployConfig.upsertDeployConfig = {
+      data: updateAppData,
+    }
+
+    // rm tmp file
+    rm(path.resolve('./.tmp'), { recursive: true }, () => {})
+
+    spinnies.succeed('up', {
+      text: `Uploading completed successfully - ${deploy_id}`,
+    })
+  } catch (error) {
+    spinnies.add('up')
+    spinnies.fail('up', { text: 'Error saving upload block' })
+  }
+}
+
+module.exports = abPremUpload
+
+/**
+ * archiver package eg, for zipping
+ */
+// https://stackoverflow.com/questions/65960979/node-js-archiver-need-syntax-for-excluding-file-types-via-glob
+// const fs = require('fs');
+// const archiver = require('archiver');
+// const output = fs.createWriteStream(__dirname);
+// const archive = archiver('zip', { zlib: { level: 9 } });
+// archive.pipe(output);
+// archive.glob('*/**', {
+//    cwd: __dirname,
+//    ignore: ['**/node_modules/*', '.git', '*.zip']
+// });
+// archive.finalize();

--- a/subcommands/upload/index.js
+++ b/subcommands/upload/index.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable no-continue */
+
+const { rm } = require('fs')
+const path = require('path')
+const chalk = require('chalk')
+const { default: axios } = require('axios')
+const { appRegistryCheckAppEnvExist } = require('../../utils/api')
+const { getShieldHeader } = require('../../utils/getHeaders')
+const deployConfig = require('../deploy/manager')
+const { spinnies } = require('../../loader')
+const { logFail } = require('../../utils')
+const { readInput } = require('../../utils/questionPrompts')
+const onPremUpload = require('./onPrem')
+const abPremUpload = require('./abPrem')
+
+const upload = async (blockName, options) => {
+  deployConfig.init()
+
+  const { environment } = options
+  const appData = deployConfig.deployAppConfig
+  const appId = appData.app_id
+
+  if (!appId) {
+    logFail(`\nPlease create app before upload..`)
+    process.exit(1)
+  }
+
+  const envData = appData.environments[environment]
+  envData.environment_name = environment
+  if (!envData) {
+    logFail(`${environment} environment not exist. Please create-env and try again\n`)
+
+    const envs = Object.keys(appData.environments)
+    if (envs.length) {
+      console.log(chalk.gray(`Existing environments are ${envs}\n`))
+    }
+
+    process.exit(1)
+  }
+
+  spinnies.add('up', { text: `Checking app details` })
+
+  // Check if app and env exist in server
+  try {
+    const { data } = await axios.post(
+      `${appRegistryCheckAppEnvExist}`,
+      {
+        app_id: appId,
+        environment_id: envData.environment_id,
+      },
+      {
+        headers: getShieldHeader(),
+      }
+    )
+
+    const resData = data.data
+
+    if (!resData) throw new Error(`Invalid response`)
+
+    if (!resData.app_exist || !resData.env_exist) {
+      const dpath = path.resolve(deployConfig.configName)
+      spinnies.fail('up', { text: ` ${!resData.app_exist ? 'App' : 'Environment'} does not exist` })
+      rm(dpath, () => {
+        process.exit(1)
+      })
+    }
+  } catch (error) {
+    spinnies.fail('up', { text: 'Error checking app data' })
+    process.exit(1)
+  }
+  spinnies.remove('up')
+
+  const uploadPremise = await readInput({
+    type: 'list',
+    name: 'uploadPremise',
+    message: 'Select the upload server',
+    choices: [
+      { name: 'On-Premise', value: 0 },
+      { name: 'Appblocks-Premise (coming soon)', value: 1, disabled: true },
+    ],
+    default: 0,
+  })
+
+  if (uploadPremise === 0) {
+    await onPremUpload({ blockName, envData, appData, environment })
+  } else {
+    await abPremUpload({ blockName, envData, appData, environment })
+  }
+}
+
+module.exports = upload
+
+/**
+ * archiver package eg, for zipping
+ */
+// https://stackoverflow.com/questions/65960979/node-js-archiver-need-syntax-for-excluding-file-types-via-glob
+// const fs = require('fs');
+// const archiver = require('archiver');
+// const output = fs.createWriteStream(__dirname);
+// const archive = archiver('zip', { zlib: { level: 9 } });
+// archive.pipe(output);
+// archive.glob('*/**', {
+//    cwd: __dirname,
+//    ignore: ['**/node_modules/*', '.git', '*.zip']
+// });
+// archive.finalize();

--- a/subcommands/upload/onPrem/awsECR/index.js
+++ b/subcommands/upload/onPrem/awsECR/index.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { spinnies } = require('../../../../loader')
+const { ecrHandler } = require('../../../../utils/aws/ecr')
+const { getBBConfig } = require('../../../../utils/config-manager')
+const { copyEmulatorCode } = require('../../../../utils/emulator-manager')
+const { generateRootPackageJsonFile, generateDockerFile } = require('./util')
+
+const onPremECRUpload = async (options) => {
+  const { appData, envData, config, deployConfigManager } = options
+  const deployedData = config.deployed || {}
+  deployedData.name = config.name
+
+  try {
+    const { app_id: appId, app_name: appName } = appData
+    const { environment_id: envId } = envData
+
+    const container = {
+      // eslint-disable-next-line no-useless-escape
+      name: config.aws_ecr.container,
+      port: 80,
+    }
+
+    const onPremDeployContentBackupFolder = deployConfigManager.getOnPremDeployContentBackupFolder({
+      suffix: '/backend/container',
+    })
+
+    let ecrData = deployedData.aws_ecr
+
+    let { dependencies } = await getBBConfig()
+    dependencies = Object.values(dependencies).filter((d) => config.blocks.includes(d.meta.name))
+
+    const container_ports = [container.port]
+    await copyEmulatorCode(container_ports, dependencies)
+    generateRootPackageJsonFile({ appName, dependencies })
+    generateDockerFile({ ports: container_ports, dependencies })
+
+    if (!ecrData?.repositoryUri) {
+      spinnies.add('ecrup', { text: `Creating image container registry for ${container.name}` })
+      ecrData = await ecrHandler.createRepository({
+        appId,
+        envId,
+        name: container.name,
+        port: container.port,
+      })
+
+      if (ecrData.error) throw ecrData.error
+
+      deployedData.aws_ecr = ecrData
+      spinnies.remove(`ecrup`)
+    }
+
+    const { error } = await ecrHandler.uploadImage({
+      container,
+      ecrData,
+      backupFolder: onPremDeployContentBackupFolder,
+    })
+
+    if (error) throw error
+
+    spinnies.add(`ecrup`, { text: `Saving ${config.name} details` })
+    deployedData.newUploads = true
+    await deployConfigManager.writeOnPremDeployedConfig({ config: deployedData, name: config.name })
+    spinnies.succeed(`ecrup`, { text: `Uploaded ${config.name} successfully` })
+  } catch (error) {
+    console.log(error)
+    deployedData.newUploads = false
+    await deployConfigManager.writeOnPremDeployedConfig({ config: deployedData, name: config.name })
+    spinnies.add('ecrup')
+    spinnies.fail('ecrup', { text: `Error: ${error.message || error}` })
+  }
+}
+
+module.exports = onPremECRUpload

--- a/subcommands/upload/onPrem/awsECR/util.js
+++ b/subcommands/upload/onPrem/awsECR/util.js
@@ -1,0 +1,78 @@
+/* eslint-disable prefer-const */
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const { writeFileSync } = require('fs')
+const { readInput } = require('../../../../utils/questionPrompts')
+
+const generateDockerFile = ({ ports, dependencies }) => {
+  const fileData = `
+#syntax=docker/dockerfile:1
+FROM node:16.3.0-alpine
+
+RUN apk --no-cache add git
+
+ENV NODE_ENV production
+
+WORKDIR .
+
+COPY ._ab_em ./._ab_em/
+COPY package.json .
+${dependencies.map((dep) => `COPY ${dep.directory} ./${dep.directory}/\n`)}
+COPY .env.function .
+
+RUN npm i
+# RUN npm ci --only=production
+
+EXPOSE ${ports}
+
+RUN npm install pm2 -g
+
+# USER node
+
+CMD ["pm2-runtime", "._ab_em/index.js", "-i max"]
+
+`
+  writeFileSync('./Dockerfile', fileData)
+}
+
+const generateRootPackageJsonFile = ({ appName, dependencies }) => {
+  // const npmInstallCmd = "npm ci --only=production"
+  const npmInstallCmd = 'npm i'
+  const postinstall = dependencies.map(({ directory }) => `(cd ${directory} && ${npmInstallCmd})`).join(';')
+
+  const fileData = `
+{
+    "name": "${appName}",
+    "version": "1.0.0",
+    "scripts": {
+      "postinstall": "(cd ._ab_em && ${npmInstallCmd});${postinstall}"
+    }
+}
+    `
+  writeFileSync('./package.json', fileData)
+}
+
+const getAWSECRConfig = async (options) => {
+  const { appName, envName } = options
+  const container = await readInput({
+    name: 'container',
+    message: 'Enter a name of container',
+    default: `${appName}${envName}container`.toLowerCase(),
+    validate: (input) => {
+      if (!input || input.length < 5) return `Name should be at least 5 characters`
+      if (!/[a-z0-9]/.test(input)) return `Name should contian only small letters and numbers`
+      return true
+    },
+  })
+  return { container }
+}
+
+module.exports = {
+  generateDockerFile,
+  generateRootPackageJsonFile,
+  getAWSECRConfig,
+}

--- a/subcommands/upload/onPrem/awsS3/index.js
+++ b/subcommands/upload/onPrem/awsS3/index.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const { spinnies } = require('../../../../loader')
+const { s3Handler } = require('../../../../utils/aws/s3')
+const { getBBConfig } = require('../../../../utils/config-manager')
+
+const onPremS3Upload = async (options) => {
+  const { config, deployConfigManager } = options
+  const deployedData = config.deployed || {}
+  deployedData.name = config.name
+
+  try {
+    const { dependencies } = await getBBConfig()
+
+    const uploadBlocks = Object.values(dependencies).reduce((acc, dep) => {
+      const { type: blockType, name: blockName } = dep.meta
+      if (!config.blocks.includes(blockName)) return acc
+      acc.push({ blockName, blockType, blockFolder: dep.directory })
+
+      return acc
+    }, [])
+
+    const bucket = config.domain
+    if (!deployedData.bucket) {
+      spinnies.add('bk', { text: `Creating bucket to upload` })
+      const { bucket: bucketName } = await s3Handler.createBucket({ bucket })
+      deployedData.bucket = bucketName
+    }
+    spinnies.remove('bk')
+
+    const uploadKeys = {}
+    const opdBackupFolder = deployConfigManager.getOnPremDeployContentBackupFolder({
+      suffix: `/frontend/build/${config.name}`,
+    })
+
+    await Promise.all(
+      uploadBlocks.map(async ({ blockName, blockType, blockFolder }) => {
+        spinnies.add(`${blockName}`, { text: `Uploading ${blockName}` })
+        try {
+          const prefix = blockType === 'ui-elements' ? blockName : null
+          const uploadedBlocks = await s3Handler.uploadDir({
+            bucket,
+            dirPath: `${blockFolder}/dist`,
+            prefix,
+            backupPath: prefix ? `${opdBackupFolder}/${prefix}` : opdBackupFolder,
+          })
+          uploadKeys[blockName] = uploadedBlocks
+          spinnies.succeed(`${blockName}`, { text: `Uploaded ${blockName}` })
+          return true
+        } catch (error) {
+          spinnies.fail(`${blockName}`, { text: `Error uploading ${blockName}: ${error.message}` })
+          return false
+        }
+      })
+    )
+
+    deployedData.uploadKeys = uploadKeys
+    deployedData.newUploads = true
+
+    spinnies.add(`ups3`, { text: `Saving ${config.name} details` })
+    await deployConfigManager.writeOnPremDeployedConfig({ config: deployedData, name: config.name })
+
+    spinnies.succeed(`ups3`, { text: `Uploaded ${config.name} successfully` })
+  } catch (error) {
+    deployedData.newUploads = false
+    await deployConfigManager.writeOnPremDeployedConfig({ config: deployedData, name: config.name })
+    spinnies.add(`ups3`)
+    spinnies.fail(`ups3`, { text: `Error: ${error.message || error}` })
+  }
+}
+
+module.exports = onPremS3Upload

--- a/subcommands/upload/onPrem/awsS3/util.js
+++ b/subcommands/upload/onPrem/awsS3/util.js
@@ -1,0 +1,26 @@
+/* eslint-disable prefer-const */
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { readInput } = require('../../../../utils/questionPrompts')
+
+const getAWSS3Config = async (options) => {
+  const { domain, uploadService } = options
+  const bucket = await readInput({
+    name: 'bucket',
+    message: 'Enter a name for bucket',
+    default: `${domain}`,
+    validate: (input) => {
+      if (!input || input.length < 3) return `Invalid input`
+      if (uploadService === 'aws_static_web_hosting' && input !== domain) return `Name should be same as domain name`
+      return true
+    },
+  })
+  return { bucket }
+}
+
+module.exports = { getAWSS3Config }

--- a/subcommands/upload/onPrem/index.js
+++ b/subcommands/upload/onPrem/index.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { awsHandler } = require('../../../utils/aws')
+const { readInput } = require('../../../utils/questionPrompts')
+const deployConfigManager = require('../../deploy/manager')
+const onPremECRUpload = require('./awsECR')
+const onPremS3Upload = require('./awsS3')
+
+const onPremUpload = async (options) => {
+  deployConfigManager.init()
+
+  await awsHandler.syncAWSConfig()
+
+  const OPDConfig = await deployConfigManager.syncOnPremDeploymentConfig(options)
+  const OPDNames = Object.keys(OPDConfig)
+
+  const choices = OPDNames.map((name) => ({ name, value: OPDConfig[name] }))
+
+  choices.unshift({
+    name: 'Create new deployment configuration',
+    value: null,
+  })
+
+  let config = await readInput({
+    type: 'list',
+    name: 'config',
+    message: 'Select upload to existing deploy config',
+    choices,
+  })
+
+  if (!config) {
+    config = await deployConfigManager.createOnPremDeploymentConfig({ ...options, existingConfigNames: OPDNames })
+  }
+
+  config.deployed = await deployConfigManager.readOnPremDeployedConfig[config.name]
+
+  const { uploadService } = config
+  switch (uploadService) {
+    case 'aws_s3':
+      await onPremS3Upload({ ...options, config, deployConfigManager })
+      break
+    case 'aws_ecr':
+      await onPremECRUpload({ ...options, config, deployConfigManager })
+      break
+    default:
+      console.log('service not supported')
+      break
+  }
+}
+
+module.exports = onPremUpload

--- a/subcommands/upload/onPrem/util.js
+++ b/subcommands/upload/onPrem/util.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const deployblockConfigManager = require('../../deploy/manager')
+
+const getExistingOPDDetails = async ({ appId, envId }) => {
+  const deployedContent = await deployblockConfigManager.readOnPremDeployedConfig()
+  return Object.fromEntries(Object.entries(deployedContent).filter((e) => e.appId === appId && e.envId === envId))
+}
+
+const saveOPDData = async ({ saveData }) => {
+  const existingData = getExistingOPDDetails({})
+  existingData[saveData.name] = saveData
+  await deployblockConfigManager.writeOnPremDeployedConfig()
+}
+
+module.exports = { getExistingOPDDetails, saveOPDData }

--- a/subcommands/upload/util.js
+++ b/subcommands/upload/util.js
@@ -1,0 +1,98 @@
+/* eslint-disable arrow-body-style */
+/* eslint-disable no-async-promise-executor */
+
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { readFileSync, existsSync, mkdirSync } = require('fs')
+const { execSync } = require('child_process')
+const chalk = require('chalk')
+const path = require('path')
+const { default: axios } = require('axios')
+const { appRegistryCreateDeployPresignedUrl } = require('../../utils/api')
+const { getShieldHeader } = require('../../utils/getHeaders')
+const { blockTypeInverter } = require('../../utils/blockTypeInverter')
+const { spinnies } = require('../../loader')
+
+const ZIP_TEMP_FOLDER = path.resolve(`./.tmp/upload`)
+const EXCLUDE_IN_ZIP = ['node_modules', '.git'].reduce((acc, ele) => `${acc} -x '${ele}/*'`, '')
+
+const uploadToServer = ({ blockType, blockId, appId, blockName, zipFile, version, blockFolder, environmentId }) => {
+  return new Promise(async (resolve) => {
+    try {
+      spinnies.update('up', { text: `Uploaded ${blockName} successfully` })
+      const preSignedData = await axios.post(
+        appRegistryCreateDeployPresignedUrl,
+        {
+          app_id: appId,
+          block_type: blockType,
+          block_folder: blockFolder,
+          block_id: blockId,
+          block_name: blockName,
+          block_version: version,
+          environment_id: environmentId,
+        },
+        {
+          headers: getShieldHeader(),
+        }
+      )
+      const zipFileData = readFileSync(zipFile)
+      await axios.put(preSignedData.data.url, zipFileData, {
+        headers: {
+          'Content-Type': 'application/zip',
+        },
+      })
+
+      spinnies.update('up', { text: `Uploaded ${blockName} successfully` })
+      resolve({
+        block_version: version,
+        block_id: blockId,
+        object_key: preSignedData.data.key,
+        block_type: blockTypeInverter(blockType),
+      })
+    } catch (err) {
+      resolve({
+        block_version: version,
+        block_id: blockId,
+        block_type: blockTypeInverter(blockType),
+        success: false,
+      })
+    }
+  })
+}
+
+const checkIfDistExist = (folder, blockName) => {
+  if (!existsSync(`${folder}/dist`)) {
+    console.log(chalk.red(`\nNo dist folder found in ${blockName}. Please build the ${blockName} app and try again`))
+    process.exit(1)
+  }
+  return true
+}
+
+const createZip = async ({ directory, blockName, type }) => {
+  let dir = `${directory}`
+
+  if (['ui-container', 'ui-elements'].includes(type)) {
+    dir = path.resolve(`${directory}/dist`)
+    checkIfDistExist(directory, blockName)
+  }
+
+  const zipFile = `${ZIP_TEMP_FOLDER}/${dir.replace(/[^/]*$/, blockName)}.zip`
+  const zipDir = `${ZIP_TEMP_FOLDER}/${dir.substring(0, dir.lastIndexOf('/'))}`
+
+  mkdirSync(zipDir, { recursive: true })
+
+  await execSync(`cd ${dir} && zip -r ${zipFile} . ${EXCLUDE_IN_ZIP}`)
+
+  return zipFile
+}
+
+module.exports = {
+  checkIfDistExist,
+  uploadToServer,
+  createZip,
+}

--- a/templates/createTemplates/function-templates/generate-packageJson.js
+++ b/templates/createTemplates/function-templates/generate-packageJson.js
@@ -11,7 +11,7 @@ const generatePackageJson = (name) => `{
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "express": "^4.17.3"
+    "express": "^4.17.3"
     }
   }
 `

--- a/templates/createTemplates/uiContainer-templates/generate-packageJson.js
+++ b/templates/createTemplates/uiContainer-templates/generate-packageJson.js
@@ -17,7 +17,7 @@ const generateUiContainerPackageJson = (name) => `
       "webpack": "5.52.0",
       "webpack-cli": "4.10.0",
       "webpack-dev-server": "4.1.0",
-          "@appblocks/node-sdk": "^0.0.3"
+      "@appblocks/node-sdk": "^0.0.3"
     },
     "scripts": {
       "start": "webpack-dev-server",
@@ -29,7 +29,7 @@ const generateUiContainerPackageJson = (name) => `
       "react": "^17.0.2",
       "react-dom": "^17.0.2",
       "react-redux": "^7.2.5",
-          "@appblocks/js-sdk": "^0.0.2"
+      "@appblocks/js-sdk": "^0.0.2"
     },
     "keywords": [],
     "author": "",

--- a/templates/createTemplates/uiElement-templates/generate-packageJson.js
+++ b/templates/createTemplates/uiElement-templates/generate-packageJson.js
@@ -26,12 +26,12 @@ const generateUiElementPackageJson = (name) => `{
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.1.0",
     "@appblocks/node-sdk": "^0.0.3",
-    "@module-federation/fmr": "^0.0.7",
+    "@module-federation/fmr": "^0.0.7"
   },
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-        "@appblocks/js-sdk": "^0.0.2"
+    "@appblocks/js-sdk": "^0.0.2"
   }
 }
 `

--- a/utils/api.js
+++ b/utils/api.js
@@ -43,16 +43,25 @@ api.listLanguageVersions = `${api.appBlockRegistryOrigin}/api/registry/public/v0
 api.listDependenciesApi = `${api.appBlockRegistryOrigin}/api/registry/public/v0.1/list-dependencies/invoke`
 api.addDependenciesApi = `${api.appBlockRegistryOrigin}/api/registry/v0.1/add-dependencies/invoke`
 api.publishBlockApi = `${api.appBlockRegistryOrigin}/api/registry/v0.1/publish-block/invoke`
+api.updateBlockApi = `${api.appBlockRegistryOrigin}/api/registry/v0.1/update-block/invoke`
+api.getBlockPersmissionsApi = `${api.appBlockRegistryOrigin}/api/registry/v0.1/get-block-permissions/invoke`
+api.trackBlockUpdatePull = `${api.appBlockRegistryOrigin}/api/registry/v0.1/track-block-updates-pull/invoke`
+api.listUnpulledBlockBersions = `${api.appBlockRegistryOrigin}/api/registry/v0.1/list-unpulled-block-versions/invoke`
 
 // APP-REGISTRY
 api.appBlockAppRegistryOrigin = `https://api-app-registry.appblocks.com`
 api.appRegistryCreateApp = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/create-app/invoke`
+api.appRegistryCheckDomainName = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/check-domain-name/invoke`
+api.appRegistryCreateEnv = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/create-hosting-environment/invoke`
 api.appRegistryCreateHostDns = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/create-host/invoke`
+api.appRegistryUpdateLiveUrl = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/update-live-url/invoke`
 api.appRegistryCreateBucket = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/create-s3-bucket/invoke`
 api.appRegistryCreateVmInstance = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/create-ec2-instance/invoke`
 api.appRegistryUploadBlockStatus = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/upload-blocks/invoke`
 api.appRegistryAddVmEnvUser = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/add-ec2-env-user/invoke`
 api.appRegistryDeployFunctions = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/deploy-functions/invoke`
+api.appRegistryProvisionApp = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/provision-app/invoke`
+api.appRegistryDeleteApp = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/delete-app/invoke`
 api.appRegistryCreateDiployHistory = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/create-deploy-history/invoke`
 api.appRegistryCheckAppEnvExist = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/check-app-env-exist/invoke`
 api.appRegistryCreateDeployPresignedUrl = `${api.appBlockAppRegistryOrigin}/api/app-registry/v0.1/create-deploy-signed-url/invoke`
@@ -66,6 +75,7 @@ api.checkBlockAssignedToApp = `${api.appBlockSpacesOrigin}/api/spaces/v0.1/check
 api.assignBlockToApp = `${api.appBlockSpacesOrigin}/api/spaces/v0.1/assign-block-to-app/invoke`
 
 // SPACES UI
+api.appBlockSpacesUIOrigin = `https://spaces.appblocks.com`
 api.publishRedirectApi = `${api.appBlockSpacesUIOrigin}`
 
 const github = {}

--- a/utils/aws/aas/index.js
+++ b/utils/aws/aas/index.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {
+  ApplicationAutoScalingClient,
+  RegisterScalableTargetCommand,
+  PutScalingPolicyCommand,
+} = require('@aws-sdk/client-application-auto-scaling')
+const { awsHandler } = require('..')
+
+class AAS_Handler {
+  // constructor() {
+  //   this.init()
+  // }
+
+  init() {
+    if (this.AASClient) return
+    const { region, accessKeyId, secretAccessKey } = awsHandler.getAWSCredConfig
+
+    this.AASClient = new ApplicationAutoScalingClient({
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    })
+  }
+
+  async registerScalableTarget(options) {
+    this.init()
+    const { clusterName, serviceName, fargateConfig } = options
+    const { maxCapacity, minCapacity } = fargateConfig
+    const ResourceId = `service/${clusterName}/${serviceName}`
+
+    const command = new RegisterScalableTargetCommand({
+      MaxCapacity: maxCapacity,
+      MinCapacity: minCapacity,
+      ResourceId,
+      ScalableDimension: 'ecs:service:DesiredCount',
+      ServiceNamespace: 'ecs',
+      // SuspendedState: {
+      //   DynamicScalingInSuspended: false,
+      //   DynamicScalingOutSuspended: false,
+      //   ScheduledScalingSuspended: false,
+      // },
+    })
+    await this.AASClient.send(command)
+    return { ResourceId }
+  }
+
+  async putScalingPolicy(options) {
+    this.init()
+    const { clusterName, serviceName } = options
+
+    const command = new PutScalingPolicyCommand({
+      PolicyName: `${serviceName}Policy`,
+      ServiceNamespace: 'ecs',
+      ResourceId: `service/${clusterName}/${serviceName}`,
+      ScalableDimension: 'ecs:service:DesiredCount',
+      PolicyType: 'TargetTrackingScaling',
+      TargetTrackingScalingPolicyConfiguration: {
+        TargetValue: 70,
+        PredefinedMetricSpecification: {
+          PredefinedMetricType: 'ECSServiceAverageCPUUtilization',
+          // ALBRequestCountPerTarget (ResourceLabel should be added)
+          // ECSServiceAverageCPUUtilization
+          // ECSServiceAverageMemoryUtilization
+        },
+        // ScaleOutCooldown: 300,
+        // ScaleInCooldown: 300,
+        // DisableScaleIn: false,
+      },
+    })
+    const { PolicyARN, Alarms } = await this.AASClient.send(command)
+    return { PolicyARN, auto_scaling_policy_arn: PolicyARN, Alarms }
+  }
+}
+
+const aasHandler = new AAS_Handler()
+module.exports = { AAS_Handler, aasHandler }

--- a/utils/aws/ec2/index.js
+++ b/utils/aws/ec2/index.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {
+  EC2Client,
+  DescribeSubnetsCommand,
+  DescribeVpcsCommand,
+  DescribeSecurityGroupsCommand,
+} = require('@aws-sdk/client-ec2')
+const { configstore } = require('../../../configstore')
+
+class EC2_Handler {
+  // constructor() {
+  //   this.init()
+  // }
+
+  init() {
+    if (this.EC2Client) return
+
+    this.awsCredConfig = configstore.get('awsCredConfig') || {}
+    const { region, accessKeyId, secretAccessKey } = this.awsCredConfig
+
+    this.EC2Client = new EC2Client({
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    })
+  }
+
+  async describeVpcs(options) {
+    this.init()
+
+    let vpcs = []
+    let nextToken
+    const { filters } = options || {}
+
+    do {
+      const input = {}
+      if (filters) input.Filters = filters
+      if (nextToken) input.NextToken = nextToken
+      const command = new DescribeVpcsCommand(input)
+      const response = await this.EC2Client.send(command)
+      nextToken = response.NextToken
+      vpcs = vpcs.concat(response.Vpcs)
+    } while (nextToken != null)
+
+    return vpcs
+  }
+
+  async describeSubnets(options) {
+    this.init()
+
+    let subnets = []
+    let nextToken
+    const { filters } = options || {}
+
+    do {
+      const input = {}
+      if (filters) input.Filters = filters
+      if (nextToken) input.NextToken = nextToken
+      const command = new DescribeSubnetsCommand(input)
+      const response = await this.EC2Client.send(command)
+      nextToken = response.NextToken
+      subnets = subnets.concat(response.Subnets)
+    } while (nextToken != null)
+
+    return subnets
+  }
+
+  async describeSecurityGroups(options) {
+    this.init()
+
+    let securityGroups = []
+    let nextToken
+    const { filters } = options || {}
+
+    do {
+      const input = {}
+      if (filters) input.Filters = filters
+      if (nextToken) input.NextToken = nextToken
+      const command = new DescribeSecurityGroupsCommand(input)
+      const response = await this.EC2Client.send(command)
+      nextToken = response.NextToken
+      securityGroups = securityGroups.concat(response.SecurityGroups)
+    } while (nextToken != null)
+
+    return securityGroups
+  }
+}
+
+const ec2Handler = new EC2_Handler()
+module.exports = { EC2_Handler, ec2Handler }

--- a/utils/aws/ecr/index.js
+++ b/utils/aws/ecr/index.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { ECRClient, CreateRepositoryCommand, GetAuthorizationTokenCommand } = require('@aws-sdk/client-ecr')
+const { execSync } = require('child_process')
+const { awsHandler } = require('..')
+const { spinnies } = require('../../../loader')
+const { runBash } = require('../../../subcommands/bash')
+
+class ECR_Handler {
+  constructor() {
+    this.init()
+  }
+
+  init() {
+    const { region, accessKeyId, secretAccessKey } = awsHandler.getAWSCredConfig
+
+    this.ECRClient = new ECRClient({
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    })
+  }
+
+  async createRepository(options) {
+    const { envId, appId, name, port } = options
+
+    const input = {
+      repositoryName: name,
+      tags: [
+        { Key: 'envId', Value: envId },
+        { Key: 'appId', Value: appId },
+      ],
+    }
+
+    try {
+      const command = new CreateRepositoryCommand(input)
+      const { repository } = await this.ECRClient.send(command)
+      const { registryId, repositoryArn, repositoryUri, repositoryName } = repository
+      return { registryId, repositoryArn, repositoryUri, repositoryName, port }
+    } catch (error) {
+      return { error }
+    }
+  }
+
+  async getECRAuthToken(registryIds) {
+    const input = {
+      registryIds,
+    }
+    const command = new GetAuthorizationTokenCommand(input)
+    const response = await this.ECRClient.send(command)
+
+    const [token] = response.authorizationData
+    return Buffer.from(token.authorizationToken, 'base64').toString().replace('AWS:', '')
+  }
+
+  async uploadImage(options) {
+    spinnies.add('upimg', { text: 'Preparing image container registry' })
+    try {
+      const { container, ecrData, backupFolder } = options
+      const containerName = container.name
+
+      const registryIds = [ecrData.registryId]
+      spinnies.update('upimg', { text: `Preparing image upload token` })
+      const ecrAuthToken = await this.getECRAuthToken(registryIds)
+
+      const { repositoryUri } = ecrData
+
+      spinnies.update('upimg', { text: `Preparing docker` })
+      await execSync(`echo "${ecrAuthToken}" | docker login --username AWS --password-stdin ${repositoryUri}`)
+      spinnies.update('upimg', { text: `Building docker image for ${containerName}` })
+      await execSync(`docker build -t ${containerName} .`, { stdio: 'inherit' })
+      spinnies.update('upimg', { text: `Adding tags to docker image for ${containerName}` })
+
+      await execSync(`docker tag ${containerName}:latest ${repositoryUri}:latest`, { stdio: 'inherit' })
+      spinnies.update('upimg', { text: `Uploading docker image for ${containerName}` })
+      await execSync(`docker push ${repositoryUri}:latest`, { stdio: 'inherit' })
+
+      if (backupFolder) {
+        spinnies.update('upimg', { text: `Saving docker image for ${containerName}` })
+        await execSync(`docker save ${containerName} > ${backupFolder}/${containerName}.tar`)
+      }
+
+      await runBash('rm -rf ./._ab_em && rm ./Dockerfile && rm ./package.json && rm ./package-lock.json')
+      spinnies.succeed('upimg', { text: `Image uploads completed successfully` })
+      return { uploaded: true }
+    } catch (error) {
+      spinnies.fail('upimg', { text: 'Image uploads failed' })
+      return { uploaded: false, error }
+    }
+  }
+}
+
+const ecrHandler = new ECR_Handler()
+module.exports = { ECR_Handler, ecrHandler }

--- a/utils/aws/ecs/index.js
+++ b/utils/aws/ecs/index.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {
+  ECSClient,
+  CreateClusterCommand,
+  CreateServiceCommand,
+  RegisterTaskDefinitionCommand,
+  UpdateServiceCommand,
+} = require('@aws-sdk/client-ecs')
+const { awsHandler } = require('..')
+
+class ECS_Handler {
+  constructor() {
+    this.init()
+  }
+
+  init() {
+    if (this.ECSClient) return
+
+    const { region, accessKeyId, secretAccessKey } = awsHandler.getAWSCredConfig
+
+    this.ECSClient = new ECSClient({
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    })
+  }
+
+  async createCluster(options) {
+    const { appId, containerName, minCapacity = 1, maxCapacity = 2 } = options
+    const command = new CreateClusterCommand({
+      clusterName: `${containerName}Cluster`,
+      tags: [{ key: 'appId', value: appId }],
+      // settings,
+      // configuration,
+      capacityProviders: ['FARGATE'],
+      defaultCapacityProviderStrategy: [
+        {
+          base: minCapacity,
+          weight: maxCapacity,
+          capacityProvider: 'FARGATE',
+        },
+      ],
+    })
+    const { cluster } = await this.ECSClient.send(command)
+
+    return { cluster, cluster_data: cluster, cluster_name: cluster.clusterName, cluster_arn: cluster.clusterArn }
+  }
+
+  async registerTaskDefinition(options) {
+    const { appId, envId, repositoryUri, repositoryName, containerName, port, fargateConfig } = options
+    const { cpu, memory } = fargateConfig || {}
+
+    const command = new RegisterTaskDefinitionCommand({
+      family: `${containerName}TD`,
+      containerDefinitions: [
+        {
+          name: repositoryName,
+          image: `${repositoryUri}:latest`,
+          portMappings: [
+            {
+              containerPort: port,
+              hostPort: port,
+              protocol: 'TCP',
+            },
+          ],
+        },
+      ],
+      executionRoleArn: 'ecsTaskExecutionRole',
+      cpu,
+      memory,
+      networkMode: 'awsvpc',
+      requiresCompatibilities: ['FARGATE'],
+      runtimePlatform: {
+        cpuArchitecture: 'X86_64',
+        operatingSystemFamily: 'LINUX',
+      },
+      tags: [
+        { key: 'envId', value: envId },
+        { key: 'appId', value: appId },
+      ],
+    })
+    const { taskDefinition } = await this.ECSClient.send(command)
+    return {
+      taskDefinition,
+      task_definition_arn: taskDefinition.taskDefinitionArn,
+      task_definition_family: taskDefinition.family,
+      task_definition_data: taskDefinition,
+    }
+  }
+
+  async createService(options) {
+    const { appId, envId, containerName, clusterArn, taskDefinitionArn, loadBalancers, fargateConfig } = options
+    const { subnetIds, securityGroupIds, desiredCount } = fargateConfig
+
+    const command = new CreateServiceCommand({
+      serviceName: `${containerName}Service`,
+      tags: [
+        { key: 'appId', value: appId },
+        { key: 'envId', value: envId },
+
+        { key: 'cluster', value: clusterArn.split('/')[1] },
+        { key: 'taskDefinition', value: taskDefinitionArn.split('/')[1] },
+      ],
+      cluster: clusterArn,
+      taskDefinition: taskDefinitionArn,
+      desiredCount,
+      networkConfiguration: {
+        awsvpcConfiguration: {
+          subnets: subnetIds,
+          securityGroups: securityGroupIds,
+          assignPublicIp: 'ENABLED',
+        },
+      },
+      loadBalancers,
+    })
+    const { service } = await this.ECSClient.send(command)
+
+    // await waitUntilServicesStable(
+    //   { client: this.ECSClient, maxWaitTime: 60 },
+    //   {
+    //     cluster: clusterArn,
+    //     services: [service.serviceName],
+    //   }
+    // )
+
+    return { service, service_data: service, service_name: service.serviceName, service_arn: service.serviceArn }
+  }
+
+  async updateService(options) {
+    const { clusterArn, serviceName } = options
+
+    const command = new UpdateServiceCommand({
+      service: serviceName,
+      cluster: clusterArn,
+      forceNewDeployment: true,
+    })
+    const { service } = await this.ECSClient.send(command)
+    return { service, service_data: service, service_name: service.serviceName, service_arn: service.serviceArn }
+  }
+}
+
+const ecsHandler = new ECS_Handler()
+module.exports = { ECS_Handler, ecsHandler }

--- a/utils/aws/elb/index.js
+++ b/utils/aws/elb/index.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {
+  ElasticLoadBalancingV2Client,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  CreateListenerCommand,
+} = require('@aws-sdk/client-elastic-load-balancing-v2')
+const { awsHandler } = require('..')
+
+class ELB_Handler {
+  constructor() {
+    this.init()
+  }
+
+  init() {
+    if (this.ELBClient) return
+    const { region, accessKeyId, secretAccessKey } = awsHandler.getAWSCredConfig
+
+    this.ELBClient = new ElasticLoadBalancingV2Client({
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    })
+  }
+
+  async createTargetGroup(options) {
+    const { appId, containerName, envId, port = 80, fargateConfig } = options
+    const { vpcId } = fargateConfig
+
+    const command = new CreateTargetGroupCommand({
+      Name: `${containerName}TG`,
+      Protocol: 'HTTP',
+      ProtocolVersion: 'HTTP1',
+      Port: port,
+      HealthCheckEnabled: true,
+      HealthCheckPath: '/',
+      HealthCheckIntervalSeconds: 60,
+      HealthCheckTimeoutSeconds: 30,
+      VpcId: vpcId,
+      TargetType: 'ip',
+      IpAddressType: 'ipv4',
+      Tags: [
+        { key: 'appId', value: appId },
+        { key: 'envId', value: envId },
+      ],
+    })
+    const { TargetGroups } = await this.ELBClient.send(command)
+    return {
+      TargetGroup: TargetGroups[0],
+      target_group_data: TargetGroups[0],
+      target_group_name: TargetGroups[0].TargetGroupName,
+      target_group_arn: TargetGroups[0].TargetGroupArn,
+    }
+  }
+
+  async createLoadBalancer(options) {
+    const { appId, envId, containerName, fargateConfig } = options
+    const { subnetIds, securityGroupIds } = fargateConfig
+
+    const command = new CreateLoadBalancerCommand({
+      Name: `${containerName}LB`,
+      Subnets: subnetIds,
+      SecurityGroups: securityGroupIds,
+      Tags: [
+        { key: 'appId', value: appId },
+        { key: 'envId', value: envId },
+      ],
+      Type: 'application',
+      IpAddressType: 'ipv4',
+      Scheme: 'internet-facing',
+    })
+    const { LoadBalancers } = await this.ELBClient.send(command)
+
+    return {
+      LoadBalancer: LoadBalancers[0],
+      load_balancer_data: LoadBalancers[0],
+      load_balancer_name: LoadBalancers[0].LoadBalancerName,
+      load_balancer_arn: LoadBalancers[0].LoadBalancerArn,
+    }
+  }
+
+  async createLoadBalancerListener(options) {
+    const { appId, envId, containerName, loadBalancerArn, targetGroupArn, port = 80 } = options
+    const command = new CreateListenerCommand({
+      LoadBalancerArn: loadBalancerArn,
+      Protocol: 'HTTP',
+      Port: port,
+      // SslPolicy: '',
+      // Certificates: '',
+      DefaultActions: [
+        {
+          Type: 'forward',
+          TargetGroupArn: targetGroupArn,
+        },
+      ],
+      // AlpnPolicy: '',
+      Tags: [
+        { key: 'appId', value: appId },
+        { key: 'envId', value: envId },
+        { key: 'containerName', value: containerName },
+      ],
+    })
+    const { Listeners } = await this.ELBClient.send(command)
+    return { Listener: Listeners[0] }
+  }
+}
+
+const elbHandler = new ELB_Handler()
+module.exports = { ELB_Handler, elbHandler }

--- a/utils/aws/index.js
+++ b/utils/aws/index.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { configstore } = require('../../configstore')
+const { readAWSCredConfig } = require('./util')
+
+class AWS_Handler {
+  constructor(options) {
+    this.awsCredConfig = {}
+    this.init(options)
+  }
+
+  init() {
+    this.awsCredConfig = this.getAWSCredConfig
+  }
+
+  async syncAWSConfig(options) {
+    const { force } = options || {}
+
+    let awsCredConfig = force ? null : this.getAWSCredConfig
+    if (!(awsCredConfig != null && Object.keys(awsCredConfig).length > 0)) {
+      awsCredConfig = await readAWSCredConfig()
+      this.setAWSCredConfig = awsCredConfig
+    }
+
+    this.awsCredConfig = awsCredConfig
+
+    return { awsCredConfig }
+  }
+
+  set setAWSCredConfig(config) {
+    this.awsCredConfig = { ...this.awsCredConfig, ...config }
+    configstore.set('awsCredConfig', this.awsCredConfig)
+  }
+
+  get getAWSCredConfig() {
+    if (!this.awsCredConfig?.accessKeyId) {
+      this.awsCredConfig = configstore.get('awsCredConfig') || {}
+    }
+    return this.awsCredConfig
+  }
+}
+
+const awsHandler = new AWS_Handler({})
+module.exports = { AWS_Handler, awsHandler }

--- a/utils/aws/s3/index.js
+++ b/utils/aws/s3/index.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {
+  S3Client,
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutBucketWebsiteCommand,
+  PutObjectCommand,
+} = require('@aws-sdk/client-s3')
+const fs = require('fs')
+const path = require('path')
+const mime = require('mime-types')
+const { awsHandler } = require('..')
+
+class S3_Handler {
+  constructor() {
+    this.init()
+  }
+
+  init() {
+    if (this.S3Client) return
+
+    const { region, accessKeyId, secretAccessKey } = awsHandler.getAWSCredConfig
+
+    this.S3Client = new S3Client({
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    })
+  }
+
+  async createBucket(options) {
+    const { bucket } = options
+    const command = new CreateBucketCommand({
+      ACL: 'public-read',
+      Bucket: bucket,
+    })
+    await this.S3Client.send(command)
+    return { bucket }
+  }
+
+  async putBucketPolicy(options) {
+    const { bucket } = options
+    const policy = `{"Version":"2012-10-17","Statement":[{"Sid":"PublicReadGetObject","Effect":"Allow","Principal":"*","Action":["s3:GetObject","s3:GetObjectVersion"],"Resource":"arn:aws:s3:::${bucket}/*"}]}`
+    const command = new PutBucketPolicyCommand({
+      Policy: policy,
+      Bucket: bucket,
+    })
+    await this.S3Client.send(command)
+    return { bucket, policy }
+  }
+
+  async putBucketWebsite(options) {
+    const { bucket } = options
+    const { region } = awsHandler.getAWSCredConfig
+    const command = new PutBucketWebsiteCommand({
+      WebsiteConfiguration: {
+        ErrorDocument: { Key: 'index.html' },
+        IndexDocument: { Suffix: 'index.html' },
+        // RedirectAllRequestsTo
+        // RoutingRules
+      },
+      Bucket: bucket,
+    })
+    await this.S3Client.send(command)
+    return { bucket, static_host: `http://${bucket}.s3-website-${region}.amazonaws.com/` }
+  }
+
+  async uploadDir(options) {
+    const { bucket, dirPath, prefix, backupPath } = options
+
+    if (backupPath) {
+      fs.cpSync(dirPath, backupPath, { overwrite: true, recursive: true })
+    }
+
+    const files = fs.readdirSync(dirPath)
+    const uploadedBlocks = []
+    const uploads = files.map(async (fileName) => {
+      const filePath = path.join(path.resolve(), dirPath, fileName)
+      const ContentType = mime.lookup(fileName) || 'application/x-javascript'
+      const Key = prefix ? `${prefix}/${fileName}` : fileName
+
+      const command = new PutObjectCommand({
+        Bucket: bucket,
+        Body: fs.createReadStream(filePath),
+        ContentType,
+        Key,
+      })
+
+      await this.S3Client.send(command)
+      uploadedBlocks.push(Key)
+    })
+
+    await Promise.all(uploads)
+    return uploadedBlocks
+  }
+}
+
+const s3Handler = new S3_Handler()
+module.exports = { S3_Handler, s3Handler }

--- a/utils/aws/util.js
+++ b/utils/aws/util.js
@@ -1,0 +1,38 @@
+const { readInput } = require('../questionPrompts')
+
+const readAWSCredConfig = async () => {
+  const accessKeyId = await readInput({
+    name: 'accessKeyId',
+    message: 'Enter aws access key ID ',
+    validate: (input) => {
+      if (!input || input?.length < 3) return `Invalid input`
+      return true
+    },
+  })
+
+  const secretAccessKey = await readInput({
+    name: 'secretAccessKey',
+    message: 'Enter aws secret access key ',
+    validate: (input) => {
+      if (!input || input?.length < 3) return `Invalid input`
+      return true
+    },
+  })
+
+  const region = await readInput({
+    name: 'region',
+    message: 'Enter aws region ',
+    validate: (input) => {
+      if (!input || input?.length < 3) return `Invalid input`
+      return true
+    },
+  })
+
+  return {
+    accessKeyId,
+    secretAccessKey,
+    region,
+  }
+}
+
+module.exports = { readAWSCredConfig }

--- a/utils/clipcopy.js
+++ b/utils/clipcopy.js
@@ -6,6 +6,7 @@
  */
 
 /* eslint-disable no-console */
+const chalk = require('chalk')
 const { execSync } = require('child_process')
 const os = require('os')
 const wslCheck = require('./wslCheck')
@@ -32,8 +33,8 @@ module.exports = async function pbcopy(data) {
           }
         } catch (e) {
           if (e.status === 127) {
-            console.log('xclip not installed')
-            console.log('please install xclip so i can copy code for you')
+            console.log(chalk.italic.gray('Please run the following command, so i can copy code for you!'))
+            console.log(chalk.green('sudo apt install xclip'))
             throw new Error('')
           } else {
             console.log('Error copying code to clipboard')
@@ -45,7 +46,7 @@ module.exports = async function pbcopy(data) {
         break
     }
   } catch (e) {
-    console.log(`Couldn't copy to clipboard`, e.message)
-    console.log(`Please copy ${data} and paste...`)
+    console.log(`\n\nCouldn't copy to clipboard`, e.message)
+    console.log(`Please copy ${chalk.whiteBright.bold(data)} and paste...`)
   }
 }

--- a/utils/createBlock.js
+++ b/utils/createBlock.js
@@ -147,10 +147,14 @@ async function createBlock(
       await Git.fetch('tempRemote')
       await Git.merge('tempRemote/main', '--allow-unrelated-histories')
       if (metaData?.version_number) {
-        // Not compatible with windows since using $() and pipe. Need to find another solution
-        await Git.revListTag(metaData?.version_number)
-        await Git.removeRemote('tempRemote')
-        await Git.removeTags('$(git tag -l)')
+        try {
+          // Not compatible with windows since using $() and pipe. Need to find another solution
+          await Git.revListTag(metaData.version_number)
+          await Git.removeRemote('tempRemote')
+          await Git.removeTags('$(git tag -l)')
+        } catch {
+          await Git.removeRemote('tempRemote')
+        }
       } else {
         await Git.removeRemote('tempRemote')
       }

--- a/utils/createComponent.js
+++ b/utils/createComponent.js
@@ -85,7 +85,8 @@ function createComponent(blockShortName, createFromExistinURL, clonePath, privat
                 appConfig.prefix || '',
                 blockShortName,
                 !!createFromExistinURL,
-                clonePath || '.'
+                clonePath || '.',
+                privateOnly
               )
               // console.log('rose', ret)
               result = ret

--- a/utils/createRepo.js
+++ b/utils/createRepo.js
@@ -48,6 +48,7 @@ async function createRepo(
   // if (!fromPull) {
   //   template = await getTemplate()
   // }
+
   const questions = [
     // {
     //   type: 'input',
@@ -64,7 +65,7 @@ async function createRepo(
       type: 'list',
       name: 'visibility',
       message: 'visibility of repo',
-      choices: [privateOnly ? 'PRIVATE' : 'PUBLIC', { name: 'PRIVATE', value: 'PRIVATE', disabled: false }],
+      choices: privateOnly ? ['PRIVATE'] : ['PUBLIC', { name: 'PRIVATE', value: 'PRIVATE', disabled: false }],
     },
   ]
 

--- a/utils/emulator-manager.js
+++ b/utils/emulator-manager.js
@@ -8,6 +8,7 @@
 
 const fs = require('fs')
 const fsPromise = require('fs/promises')
+const isRunning = require('is-running')
 const path = require('path')
 // const { readdirSync, readFileSync, existsSync } = require('fs')
 // const { execSync } = require('child_process')
@@ -231,13 +232,15 @@ async function stopEmulator(rootPath) {
   //     })
   //   )
   // } else {
-  const processData = await getEmulatorProcessData(rootPath)
-  if (processData && processData.pid) {
-    await runBash(`kill ${processData.pid}`)
-  }
+  if (fs.existsSync(path.join(rootPath, '._ab_em'))) {
+    const processData = await getEmulatorProcessData(rootPath)
+    if (processData && processData.pid && isRunning(processData.pid)) {
+      await runBash(`kill ${processData.pid}`)
+    }
 
-  await runBash(`rm -rf ${path.join(rootPath, '._ab_em')}`)
-  console.log('emulator stopped successfully!')
+    await runBash(`rm -rf ${path.join(rootPath, '._ab_em')}`)
+    console.log('emulator stopped successfully!')
+  }
   // }
 }
 

--- a/utils/ensureUserLogins.js
+++ b/utils/ensureUserLogins.js
@@ -16,22 +16,24 @@ const { getShieldSignedInUser } = require('./getSignedInUser')
 const { configstore } = require('../configstore')
 const { spinnies } = require('../loader')
 
-async function ensureUserLogins() {
+async function ensureUserLogins(noRepo) {
   spinnies.add('logins', { text: 'Checking Git auths' })
 
-  const { redoAuth } = await checkAndSetAuth()
-  if (redoAuth) {
-    spinnies.update('logins', {
-      text: 'Git not logged in',
-      status: 'stopped',
-      color: 'yellow',
-    })
+  if (!noRepo) {
+    const { redoAuth } = await checkAndSetAuth()
+    if (redoAuth) {
+      spinnies.update('logins', {
+        text: 'Git not logged in',
+        status: 'stopped',
+        color: 'yellow',
+      })
 
-    const response = await axios.post(githubGetDeviceCode, {
-      client_id: githubClientID,
-      scope: 'repo,read:org,delete_repo',
-    })
-    await handleGithubAuth(decodeURIComponent(response.data))
+      const response = await axios.post(githubGetDeviceCode, {
+        client_id: githubClientID,
+        scope: 'repo,read:org,delete_repo',
+      })
+      await handleGithubAuth(decodeURIComponent(response.data))
+    }
   }
   if (!spinnies.hasActiveSpinners()) {
     spinnies.add('logins', { text: 'Git auth done' })

--- a/utils/errors/baseError.js
+++ b/utils/errors/baseError.js
@@ -9,6 +9,7 @@ class BBError extends Error {
   constructor(message) {
     super(message)
     this.name = this.constructor.name
+    this.processExitCode = 0
   }
 }
 

--- a/utils/errors/blockPushError.js
+++ b/utils/errors/blockPushError.js
@@ -8,11 +8,12 @@
 const { BBError } = require('./baseError')
 
 class BlockPushError extends BBError {
-  constructor(path, block, message, resetHead) {
+  constructor(path, block, message, resetHead, exitCode) {
     super(`${message} in ${path}`)
     this.blockPath = path
     this.blockName = block
     this.resetHead = resetHead
+    this.processExitCode = exitCode
   }
 }
 

--- a/utils/errors/gitError.js
+++ b/utils/errors/gitError.js
@@ -14,6 +14,7 @@ class GitError extends BBError {
     this.options = options
     this.gitDirPath = path
     this.resetHead = resetHead
+    this.processExitCode = 1
   }
 }
 

--- a/utils/handleGithubAuth.js
+++ b/utils/handleGithubAuth.js
@@ -25,7 +25,7 @@ async function handleGithubAuth(data) {
   console.log('Please go to https://github.com/login/device, and paste the below code.')
   await figletAsync(userCode)
   console.log('\n')
-  clipcopy(userCode)
+  await clipcopy(userCode)
   console.log('\n')
   // const timerThread={killed:true} -- for token expired testing.
   console.log(`Code expires in ${chalk.bold(expiresIn)} seconds `)

--- a/utils/multibar.js
+++ b/utils/multibar.js
@@ -18,6 +18,9 @@ const formatFn = (options, params, payload) => {
   if (payload.status === 'success') {
     return chalk.green(`${payload.block} ${bar} ${Math.floor(params.progress * 100)}% | ${payload.status} `)
   }
+  if (payload.status === 'warning') {
+    return chalk.yellow(`${payload.block} ${bar} ${Math.floor(params.progress * 100)}% | ${payload.status} `)
+  }
   return `${payload.block} ${bar} ${Math.floor(params.progress * 100)}% | ${payload.status} `
 }
 

--- a/utils/preActionRunner.js
+++ b/utils/preActionRunner.js
@@ -11,7 +11,10 @@ const { ensureUserLogins } = require('./ensureUserLogins')
 const { isInGitRepository, isGitInstalled } = require('./gitCheckUtils')
 const { checkLogDirs } = require('./preActionMethods/preAction-start')
 
-const preActionChecks = async (subcommand) => {
+const preActionChecks = async (actionCommand) => {
+  const noRepo = !actionCommand._optionValues?.repo
+  const subcommand = actionCommand.parent.args[0]
+
   switch (subcommand) {
     // To add command specific checks
     case 'start':
@@ -95,7 +98,7 @@ const preActionChecks = async (subcommand) => {
         console.log('Git not installed')
         process.exit(1)
       }
-      await ensureUserLogins()
+      await ensureUserLogins(noRepo)
       await checkAndSetGitConnectionPreference()
       await checkAndSetUserSpacePreference()
       break

--- a/utils/pushBlocks.js
+++ b/utils/pushBlocks.js
@@ -40,7 +40,7 @@ function pushBlocks(gitUserName, gitUserEmail, commitMessage, blocksToPush) {
             (acc, v) => {
               // console.log(v)
               if (v.status === 'rejected') {
-                pushReport[v.reason.name] = v.reason.data.message
+                pushReport[v.reason.name] = v.reason.data
                 return { ...acc, failed: acc.failed + 1 }
               }
               return { ...acc, success: acc.success + 1 }
@@ -56,8 +56,7 @@ function pushBlocks(gitUserName, gitUserEmail, commitMessage, blocksToPush) {
           // console.log(pushReport)
           for (const key in pushReport) {
             if (Object.hasOwnProperty.call(pushReport, key)) {
-              const element = pushReport[key]
-              feedback({ type: 'error', message: element })
+              feedback({ type: pushReport[key]?.type, message: pushReport[key]?.message })
             }
           }
           res('Completed push')


### PR DESCRIPTION

## Summary
This PR includes the changes made to make pulling purchased blocks and its setup, fixes and 3 new features

## Features
1.  During block push, progress bar showed an error if there are no files to stage in block. It'll now be shown as a warning.
2.  Proper error message will be shown in push report, if block is not registered or is not found in registry rather than a "something went wrong"
3. Both `init` and `create` command will accept a `no-repo` option which will bypass the git user logins and prompt the user to provide a git **ssh** for an **EMPTY REPO** . blocks created with this option will have to be synced later using `sync` command
4. Purchased block flow
5. `is-running` package is used to check the status of a block using the pid, during config refreshs

## Fixes
1. File missing error
2. Uncaught errors
3. Json syntax error in generated templates
4. x-clip not installed error showing in between a prompt and answer