### PR TITLE
fix: create thought init - block pulled to wrong path

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -57,6 +57,7 @@ const deleteCommand = require('../subcommands/delete')
 const listLanguageVersionCommand = require('../subcommands/languageVersion/list')
 const createBlockVersion = require('../subcommands/createBlockVersion/index')
 const getBlockUpdate = require('../subcommands/getBlockUpdate')
+const { blockTypeInverter } = require('../utils/blockTypeInverter')
 
 inquirer.registerPrompt('file-tree-selection', inquirerFileTree)
 inquirer.registerPrompt('customList', customList)
@@ -110,21 +111,23 @@ async function init() {
     .command('create')
     .argument('<component>', 'name of component')
     .addOption(
-      new Option('-t, --type <component-type>', 'type  of comp').choices(
-        blockTypes.reduce((acc, v) => {
-          if (v[0] !== 'appBlock') return acc.concat(v[0])
-          return acc
-        }, [])
-      )
+      new Option('-t, --type <component-type>', 'type  of comp')
+        .choices(
+          blockTypes.reduce((acc, v) => {
+            if (v[0] !== 'appBlock') return acc.concat(v[0])
+            return acc
+          }, [])
+        )
+        .argParser((s) => blockTypeInverter(s))
     )
-    .option('--no-repo')
+    .option('--no-autoRepo')
     .description('to create components')
     .action(create)
 
   program
     .command('init')
     .argument('<appblock-name>', 'Name of app')
-    .option('--no-repo')
+    .option('--no-autoRepo')
     .description('create an appblock')
     .action(packageBlockInit)
 

--- a/subcommands/__tests__/create.test.js
+++ b/subcommands/__tests__/create.test.js
@@ -50,6 +50,13 @@ afterAll(() => {
   logSpy.mockRestore()
 })
 
+describe('new cases', () => {
+  test('Should init config if skipConfigInit is false', async () => {
+    await create('aname', { type: 'function', noRepo: false }, {}, false, '.', false)
+    expect(appConfig.init).toHaveBeenCalled()
+  })
+})
+
 describe('Create called with no args', () => {
   beforeEach(() => {})
   beforeAll(() => {

--- a/subcommands/init/index.js
+++ b/subcommands/init/index.js
@@ -12,8 +12,8 @@ const { setWithTemplate } = require('../../utils/questionPrompts')
 const setupTemplate = require('./setupTemplate')
 const initializePackageBlock = require('./initializePackageBlock')
 
-const init = async (appblockName) => {
-  const initializedData = await initializePackageBlock(appblockName)
+const init = async (appblockName, options) => {
+  const initializedData = await initializePackageBlock(appblockName, options)
   const { useTemplate } = await setWithTemplate()
   if (useTemplate) await setupTemplate(initializedData)
 

--- a/utils/checkBlockNameAvailability.js
+++ b/utils/checkBlockNameAvailability.js
@@ -63,7 +63,7 @@ async function check(name) {
  *
  * @param {String} passedName Name to check
  * @param {Boolean} bypassInitialCheck To bypass initial check and ask for a new name
- * @returns {String} An available name
+ * @returns {Promise<String>} An available name
  */
 async function checkBlockNameAvailability(passedName, bypassInitialCheck) {
   if (!bypassInitialCheck) {

--- a/utils/createBlock.js
+++ b/utils/createBlock.js
@@ -38,7 +38,7 @@ const registerBlock = require('./registerBlock')
  * @param {String} cwd To pass to directory creation function
  * @param {Boolean?} isAStandAloneBlock If user is trying to create a block outside appblock context
  * @param {Object?} Configuration of job
- * @returns {returnObject}
+ * @returns {Promise<returnObject>}
  */
 async function createBlock(
   blockName,

--- a/utils/fileAndFolderHelpers.js
+++ b/utils/fileAndFolderHelpers.js
@@ -291,7 +291,7 @@ function createDirForType(type, cwd) {
  *
  * @param {String} dirname
  * @param  {...any} acceptedItems List of accepted file or folder names
- * @returns {Boolean}
+ * @returns {Promise<Boolean>}
  */
 function isDirEmpty(dirname, ...acceptedItems) {
   return fs.promises.readdir(dirname).then((files) => {

--- a/utils/noRepo.js
+++ b/utils/noRepo.js
@@ -1,0 +1,19 @@
+const convertGitSshUrlToHttps = require('./convertGitUrl')
+const { sourceUrlOptions, readInput } = require('./questionPrompts')
+
+/**
+ * Prompts user with two options, "cancel" and "let me provide URL"
+ * @returns {Promise<import('./jsDoc/types').blockSource>}
+ */
+async function getRepoUrl() {
+  // 0 for cancel
+  // 1 for let me provide url
+  const o = await sourceUrlOptions()
+  if (o === 1) {
+    const s = await readInput({ message: 'Enter source ssh url here', name: 'sUrl' })
+    return { ssh: s.trim(), https: convertGitSshUrlToHttps(s.trim()) }
+  }
+  return { ssh: '', https: '' }
+}
+
+module.exports = getRepoUrl

--- a/utils/questionPrompts.js
+++ b/utils/questionPrompts.js
@@ -49,6 +49,10 @@ function getBlockName() {
     .catch((err) => console.log(err))
 }
 
+/**
+ *
+ * @returns {Promise<(0 | 1 | 2)>}
+ */
 function sourceUrlOptions() {
   const questions = [
     {
@@ -57,7 +61,6 @@ function sourceUrlOptions() {
       message: 'Would you like to provide a source url',
       choices: [
         { name: 'Yes, let me share', value: 1 },
-        { name: 'No, take me to connect', value: 2 },
         { name: 'cancel', value: 0 },
       ],
     },


### PR DESCRIPTION
## Fix
Running create command out of context takes CLI to `init` flow, and moves back to create once package is created. This flow was creating package and block in the same directory rather than block inside package.
issue is fixed in this PR

`--no-autoRepo`  flow fix

refactoring

