### PR TITLE
space restriction in pacakge block, sync re-register & version tied readme

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -14,7 +14,7 @@ const chalk = require('chalk')
 portfinder.basePort = 8002
 
 const { respondWithFile, getCallbackUrl, getLoginUrl } = require('./utils/authUtils')
-const { appBlockLogin, appBlockAccessToken } = require('./utils/api')
+const { appBlockLogin, appBlockAccessToken, clientId } = require('./utils/api')
 const { getDeviceCode } = require('./utils/questionPrompts')
 
 module.exports = {
@@ -81,7 +81,7 @@ async function getTokensFromAuthorizationCode(code) {
 }
 async function loginWithoutLocalhost() {
   const callbackUrl = getCallbackUrl()
-  const authUrl = getLoginUrl(appBlockLogin, callbackUrl, 'userhint', _nonce, 'device_code', 'console-appblocks-1842')
+  const authUrl = getLoginUrl(appBlockLogin, callbackUrl, 'userhint', _nonce, 'device_code', clientId)
 
   // logger.info();
   // logger.info("Visit this URL on any device to log in:");
@@ -198,7 +198,7 @@ async function loginWithAppBlock(localhost, userHint) {
  */
 async function loginWithLocalhostAppBlock(port) {
   const callbackUrl = getCallbackUrl(port)
-  const authUrl = getLoginUrl(appBlockLogin, callbackUrl, 'userhint', _nonce, 'device_code', 'console-appblocks-1842')
+  const authUrl = getLoginUrl(appBlockLogin, callbackUrl, 'userhint', _nonce, 'device_code', clientId)
   // console.log(port, authUrl, callbackUrl)
   // const successTemplate = "../templates/loginSuccess.html";
   const tokens = await loginWithLocalhost(

--- a/subcommands/createBlockVersion/index.js
+++ b/subcommands/createBlockVersion/index.js
@@ -12,10 +12,12 @@ const { spinnies } = require('../../loader')
 const { appBlockAddVersion } = require('../../utils/api')
 const { appConfig } = require('../../utils/appconfigStore')
 const convertGitSshUrlToHttps = require('../../utils/convertGitUrl')
+const { ensureReadMeIsPresent, uploadReadMe } = require('../../utils/fileAndFolderHelpers')
 const { getShieldHeader } = require('../../utils/getHeaders')
 const { isClean, getLatestVersion } = require('../../utils/gitCheckUtils')
 const { GitManager } = require('../../utils/gitmanager')
 const { readInput } = require('../../utils/questionPrompts')
+const { updateReadme } = require('../../utils/registryUtils')
 
 const createBlockVersion = async (blockname) => {
   await appConfig.init(null, null)
@@ -44,6 +46,13 @@ const createBlockVersion = async (blockname) => {
 
     if (!isClean(blockDetails.directory)) {
       console.log('Git directory is not clean, Please push before publish')
+      process.exit(1)
+    }
+
+    // ------------------------------------------ //
+    const [readmePath] = ensureReadMeIsPresent(blockDetails.directory, blockname, false)
+    if (!readmePath) {
+      console.log('Make sure to add a README.md ')
       process.exit(1)
     }
 
@@ -100,10 +109,25 @@ const createBlockVersion = async (blockname) => {
     if (data.err) {
       throw new Error('Something went wrong from our side\n', data.msg).message
     }
+    const versionId = data?.data?.id
+
+    spinnies.update('p1', { text: `Uploading readme` })
+    const res = await uploadReadMe(readmePath, blockId, versionId)
+    if (res.status !== 200) {
+      throw new Error('Something went wrong while uploading readme.')
+    }
+
+    spinnies.update('p1', { text: `Updating readme` })
+    const upResp = await updateReadme(blockId, versionId, res.key)
+    if (upResp.status !== 200) {
+      throw new Error('Something went wrong while updating readme.')
+    }
+    spinnies.update('p1', { text: `ReadMe updated succesfully` })
+
     spinnies.succeed('p1', { text: `new version created successfully` })
   } catch (error) {
-    spinnies.add('p1_error', { text: 'Error' })
-    spinnies.fail('p1_error', { text: error.message })
+    spinnies.add('p1', { text: 'Error' })
+    spinnies.fail('p1', { text: error.message })
     process.exit(1)
   }
 }

--- a/subcommands/init/index.js
+++ b/subcommands/init/index.js
@@ -11,9 +11,11 @@ const chalk = require('chalk')
 const { setWithTemplate } = require('../../utils/questionPrompts')
 const setupTemplate = require('./setupTemplate')
 const initializePackageBlock = require('./initializePackageBlock')
+const initializeSpaceToPackageBlock = require('./initializeSpaceToPackageBlock')
 
 const init = async (appblockName, options) => {
   const initializedData = await initializePackageBlock(appblockName, options)
+  await initializeSpaceToPackageBlock(initializedData.blockFinalName)
   const { useTemplate } = await setWithTemplate()
   if (useTemplate) await setupTemplate(initializedData)
 

--- a/subcommands/init/initializeSpaceToPackageBlock.js
+++ b/subcommands/init/initializeSpaceToPackageBlock.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { configstore } = require('../../configstore')
+const { lrManager } = require('../../utils/locaRegistry/manager')
+
+const initializeSpaceToPackageBlock = async (blockFinalName) => {
+  await lrManager.init()
+  lrManager.linkSpaceToPackageBlock({
+    name: blockFinalName,
+    space_id: configstore.get('currentSpaceId'),
+    space_name: configstore.get('currentSpaceName'),
+  })
+}
+
+module.exports = initializeSpaceToPackageBlock

--- a/subcommands/login.js
+++ b/subcommands/login.js
@@ -17,19 +17,19 @@ const login = async (options) => {
   const presentTOKEN = configstore.get('appBlockUserToken', '')
 
   if (presentTOKEN) {
-    const user = await getShieldSignedInUser(presentTOKEN)
-    if (user.user === configstore.get('appBlockUserName', '')) {
-      console.log(`Already signed in as ${user.user}`)
+    const { user } = await getShieldSignedInUser(presentTOKEN)
+    if (user && user === configstore.get('appBlockUserName', '')) {
+      console.log(`Already signed in as ${user}`)
       return
     }
   }
   const { localhost } = options
   const { data } = await loginWithAppBlock(localhost)
   configstore.set('appBlockUserToken', data.access_token)
-  const user = await getShieldSignedInUser(data.access_token)
-  configstore.set('appBlockUserName', user.user)
+  const { user } = await getShieldSignedInUser(data.access_token)
+  configstore.set('appBlockUserName', user)
 
-  feedback({ type: 'success', message: `Successfully logged in as ${user.user}` })
+  feedback({ type: 'success', message: `Successfully logged in as ${user}` })
 }
 
 module.exports = login

--- a/subcommands/ls.js
+++ b/subcommands/ls.js
@@ -23,19 +23,18 @@ const { appConfig } = require('../utils/appconfigStore')
  */
 const rowGenerate = (isLive, g) => {
   const { red, whiteBright, green } = chalk
-  if (isLive) {
-    const url = ['function', 'job'].includes(g.meta.type) ? `localhost:${g.port}/${g.meta.name}` : `localhost:${g.port}`
-    return [
-      whiteBright(g.meta.name),
-      g.meta.type,
-      g.pid,
-      g.port,
-      { content: url, href: `http://${url}` },
-      g.log.out,
-      green('LIVE'),
-    ]
-  }
-  return [whiteBright(g.meta.name), g.meta.type, 'Null', 'Null', '...', '...', red('OFF')]
+  const { meta } = g
+  const { name, type } = meta
+
+  if (!isLive) return [whiteBright(name), type, 'Null', 'Null', '...', '...', red('OFF')]
+
+  let url = `localhost:${g.port}`
+
+  if (type === 'shared-fn') url = ''
+  if (type === 'function') url = `localhost:${g.port}/${name}`
+  if (type === 'job') url = `localhost:${g.port}/${name}`
+
+  return [whiteBright(name), type, g.pid, g.port, { content: url, href: `http://${url}` }, g.log.out, green('LIVE')]
 }
 
 const ls = async (options) => {

--- a/subcommands/pull/util.js
+++ b/subcommands/pull/util.js
@@ -301,6 +301,28 @@ async function pullBlock(da, appConfig, cwd, componentName, options) {
             process.exit(1)
           }
         } else {
+          const packageBlockName = appConfig.config?.name
+          let package_block_id
+
+          if (packageBlockName) {
+            const {
+              status,
+              data: { err, msg, data: packageBlockDetails },
+            } = await getBlockDetails(packageBlockName)
+
+            if (status === 204) {
+              feedback({ type: 'info', message: `${packageBlockName} doesn't exists in block repository` })
+              return
+            }
+            if (err) throw new Error(msg).message
+
+            package_block_id = packageBlockDetails.ID
+          }
+
+          if (!packageBlockName && metaData.BlockType !== 1) {
+            throw new Error('Cannot create block without package block')
+          }
+
           const createBlockRes = await createBlock(
             availableName,
             availableName,
@@ -310,7 +332,8 @@ async function pullBlock(da, appConfig, cwd, componentName, options) {
             cwd,
             false,
             null,
-            metaData
+            metaData,
+            package_block_id
           )
 
           clonePath = createBlockRes.clonePath

--- a/subcommands/pull/util.js
+++ b/subcommands/pull/util.js
@@ -242,6 +242,7 @@ async function pullBlock(da, appConfig, cwd, componentName, options) {
 
     let createCustomVersion
     if (isPurcahsedVariant && blockVisibility !== 5) {
+      // FOR NOW: No variant allowed for purchased variant
       createCustomVersion = false
     } else if (addVariant === true || (isPurcahsedVariant && blockVisibility === 5)) {
       createCustomVersion = true
@@ -366,7 +367,7 @@ async function pullBlock(da, appConfig, cwd, componentName, options) {
       const localDirName = `${metaData.BlockName}`
       const blockFolderPath = path.resolve(clonePath, localDirName)
 
-      if (hasBlockAccess) {
+      if (hasPullBlockAccess) {
         if (isPurcahsedVariant) {
           const checkData = await checkIsBlockAppAssinged({ metaData })
           if (!checkData.exist) {

--- a/subcommands/start.js
+++ b/subcommands/start.js
@@ -141,7 +141,7 @@ async function startAllBlock() {
   // Build env for all blocks
   const PORTS = await getFreePorts(appConfig)
 
-  spinnies.add('emulator', { text: 'Staring emulator' })
+  spinnies.add('emulator', { text: 'Starting emulator' })
   switch (emulateLang) {
     case 'nodejs':
       emData = await emulateNode(PORTS.emulatorPorts, [...appConfig.dependencies])

--- a/subcommands/use.js
+++ b/subcommands/use.js
@@ -42,12 +42,14 @@ const promptAndSetSpace = async (Data) => {
 const use = async (space_name) => {
   // check space is linked with block
   await appConfig.init()
+  const currentSpaceName = configstore.get('currentSpaceName')
+
   if (appConfig.isInAppblockContext || appConfig.isInBlockContext) {
-    feedback({ type: 'error', message: 'Switiching spaces is not allowed inside block context' })
+    console.log(chalk.dim(`current space is ${currentSpaceName}`))
+    feedback({ type: 'error', message: `Switiching spaces is not allowed inside block context` })
     process.exit(1)
   }
 
-  const currentSpaceName = configstore.get('currentSpaceName')
   if (space_name && currentSpaceName === space_name) {
     feedback({ type: 'info', message: `${space_name} is already set` })
     process.exit(0)

--- a/subcommands/use.js
+++ b/subcommands/use.js
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const chalk = require('chalk')
 const { prompt } = require('inquirer')
 const { configstore } = require('../configstore')
+const { appConfig } = require('../utils/appconfigStore')
 const { feedback } = require('../utils/cli-feedback')
 const { listSpaces } = require('../utils/spacesUtils')
 
@@ -38,11 +40,21 @@ const promptAndSetSpace = async (Data) => {
  * @returns
  */
 const use = async (space_name) => {
+  // check space is linked with block
+  await appConfig.init()
+  if (appConfig.isInAppblockContext || appConfig.isInBlockContext) {
+    feedback({ type: 'error', message: 'Switiching spaces is not allowed inside block context' })
+    process.exit(1)
+  }
+
   const currentSpaceName = configstore.get('currentSpaceName')
   if (space_name && currentSpaceName === space_name) {
     feedback({ type: 'info', message: `${space_name} is already set` })
     process.exit(0)
   }
+
+  console.log(chalk.dim(`current space is ${currentSpaceName}`))
+
   try {
     const res = await listSpaces()
     if (res.data.err) {

--- a/utils/api.js
+++ b/utils/api.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+const clientId = 'console-appblocks-1842'
 
 const api = {}
 // api.appBlockOrigin = `http://shield.appblock.io`
@@ -11,6 +12,7 @@ api.appBlockOrigin = `https://shield.appblocks.com`
 api.appBlockLogin = `${api.appBlockOrigin}/login`
 api.appBlockLogout = `${api.appBlockOrigin}/logout`
 api.appBlockAccessToken = `${api.appBlockOrigin}/auth/device/get-token`
+api.appBlockVerifyToken = `${api.appBlockOrigin}/device/verify-token`
 
 // BLOCKS-REGISTRY
 api.appBlockRegistryOrigin = `https://api-blocks-registry.appblocks.com`
@@ -88,4 +90,4 @@ github.githubGetDeviceCode = `${github.githubLogin}/device/code`
 github.githubGetAccessToken = `${github.githubLogin}/oauth/access_token`
 github.githubClientID = '5a77c38abd2e3e84d4e9'
 
-module.exports = { ...api, ...github }
+module.exports = { ...api, ...github, clientId }

--- a/utils/appconfig-manager.js
+++ b/utils/appconfig-manager.js
@@ -217,6 +217,11 @@ class AppblockConfigManager {
     return this.getDependencies(false, filter)
   }
 
+  get sharedFnBlocks() {
+    const filter = (block) => ['shared-fn'].includes(block.meta.type)
+    return this.getDependencies(false, filter)
+  }
+
   get jobBlocks() {
     const filter = (block) => ['job'].includes(block.meta.type)
     return this.getDependencies(false, filter)

--- a/utils/blockPushProcess.js
+++ b/utils/blockPushProcess.js
@@ -12,11 +12,10 @@ const { configstore } = require('../configstore')
 const convertGitSshUrlToHttps = require('./convertGitUrl')
 const { BlockPushError } = require('./errors/blockPushError')
 const { GitError } = require('./errors/gitError')
-const { ensureReadMeIsPresent, uploadReadMe } = require('./fileAndFolderHelpers')
+const { ensureReadMeIsPresent } = require('./fileAndFolderHelpers')
 const { checkAndSetGitConfigNameEmail, gitCommitWithMsg, gitStageAllIn } = require('./gitCheckUtils')
 const { GitManager } = require('./gitmanager')
 const { logger } = require('./logger')
-const { getBlockDetails, updateReadme } = require('./registryUtils')
 
 const start = async ({ blockName, blockPath, blockSource, commitMessage, gitUserName, gitUserEmail }) => {
   try {
@@ -64,67 +63,11 @@ const start = async ({ blockName, blockPath, blockSource, commitMessage, gitUser
 
     // ------------------------------------------ //
 
-    const res = await uploadReadMe(readmePath)
-    if (res.status !== 200) {
-      logger.error('Something went wrong while uploading readme..refer next entry for error info')
-      logger.error(res.error)
-      throw new BlockPushError(blockPath, blockName, res.error, false, 1)
-      // process.exit(1)
-    }
-    logger.info('Uploaded readme succesfully')
-    process.send({ failed: false, message: 'Readme updated...' })
-
-    // ------------------------------------------ //
-
     process.send({ failed: false, message: 'Pushing..' })
     // await gitPushAllIn(blockPath)
     await Git.push('main')
     logger.info('Commits pushed succesfully')
     process.send({ failed: false, message: 'Commits pushed..' })
-
-    // ------------------------------------------ //
-
-    let metaData
-    try {
-      const resp = await getBlockDetails(blockName)
-      if (resp.status === 204) throw new Error(`${blockName} doesn't exists in block repository`).message
-      const { data } = resp
-      if (data.err) {
-        // if (data.msg === 'NO RECORD FOUND') {
-        //   throw new Error(`${blockName} doesn't exists in block repository`)
-        // }
-        // TODO -- throw a Registry error here
-        throw new Error('Something went wrong from our side\n', data.msg).message
-      }
-
-      metaData = data.data
-    } catch (err) {
-      logger.error(`Something went wrong while getting details of block:${blockName} -- ${err} `)
-      throw new BlockPushError(
-        blockPath,
-        blockName,
-        err || `Something went wrong while getting details of ${blockName}`,
-        false,
-        2
-      )
-      // process.exit(1)
-    }
-
-    logger.info('Block details fetched successfully')
-
-    // ------------------------------------------ //
-
-    // TODO -- move JsDoc typedefs to one file
-    // console.log(metaData)
-    process.send({ failed: false, message: 'Updating registry..' })
-    const resp = await updateReadme(metaData.ID, res.key, metaData.IsPublic)
-    if (!resp.data?.err) {
-      logger.info('Registry updated succesfully')
-      process.send({ failed: false, message: 'Updated registry..' })
-    }
-    // TODO -- catch updateReadme error here and throw as Registry error
-    // console.log(resp)
-    // ------------------------------------------ //
 
     process.exitCode = 0
   } catch (err) {

--- a/utils/checkAndSetUserSpacePreference.js
+++ b/utils/checkAndSetUserSpacePreference.js
@@ -7,14 +7,55 @@
 
 const { prompt } = require('inquirer')
 const { configstore } = require('../configstore')
+const { appConfig } = require('./appconfigStore')
 const { feedback } = require('./cli-feedback')
+const { lrManager } = require('./locaRegistry/manager')
+const { confirmationPrompt } = require('./questionPrompts')
 const { listSpaces } = require('./spacesUtils')
+
+async function checkSpaceLinkedToPackageBlock() {
+  // check space is linked with package block
+  await appConfig.init()
+  if (appConfig.isInAppblockContext || appConfig.isInBlockContext) {
+    const { name } = appConfig.config
+    await lrManager.init()
+
+    const spaceId = configstore.get('currentSpaceId')
+
+    if (!spaceId || !lrManager.isSpaceLinkedToPackageBlock(name, spaceId)) {
+      const { space_name, space_id } = lrManager.linkedSpaceOfPackageBlock(name)
+
+      if (!space_name) return false
+
+      const switchSpace = await confirmationPrompt({
+        name: 'switchSpace',
+        message: `${name} package block is linked to space ${space_name}. Do you want to set space to ${space_name}`,
+        default: true,
+      })
+
+      if (!switchSpace) {
+        feedback({ type: 'error', message: `Access denied` })
+        process.exit(0)
+      }
+
+      // TODO: Check for space existance
+      configstore.set('currentSpaceName', space_name)
+      configstore.set('currentSpaceId', space_id)
+
+      feedback({ type: 'success', message: `Current Space: ${configstore.get('currentSpaceName')}` })
+    }
+  }
+  return true
+}
 
 async function checkAndSetUserSpacePreference() {
   const currentSpaceName = configstore.get('currentSpaceName')
 
   if (!currentSpaceName) {
     try {
+      const isLinked = await checkSpaceLinkedToPackageBlock()
+      if (isLinked) return
+
       const res = await listSpaces()
       if (res.data.err) {
         feedback({ type: 'error', message: res.data.msg })
@@ -46,7 +87,8 @@ async function checkAndSetUserSpacePreference() {
     // If the call to list spaces fails here continue with the
     // present space name and hope it works.No need to abort then.
     // If the space is not present in the returned list, prompt for new space selection
-    feedback({ type: 'info', message: `CURRENT SPACE-${currentSpaceName}` })
+    feedback({ type: 'success', message: `Current Space: ${currentSpaceName}` })
+    await checkSpaceLinkedToPackageBlock()
   }
 }
 module.exports = checkAndSetUserSpacePreference

--- a/utils/checkAndSetUserSpacePreference.js
+++ b/utils/checkAndSetUserSpacePreference.js
@@ -23,7 +23,7 @@ async function checkSpaceLinkedToPackageBlock() {
     const spaceId = configstore.get('currentSpaceId')
 
     if (!spaceId || !lrManager.isSpaceLinkedToPackageBlock(name, spaceId)) {
-      const { space_name, space_id } = lrManager.linkedSpaceOfPackageBlock(name)
+      const { space_name, space_id } = await lrManager.linkedSpaceOfPackageBlock(name)
 
       if (!space_name) return false
 
@@ -34,7 +34,7 @@ async function checkSpaceLinkedToPackageBlock() {
       })
 
       if (!switchSpace) {
-        feedback({ type: 'error', message: `Access denied` })
+        feedback({ type: 'error', message: `Access denied for current space` })
         process.exit(0)
       }
 
@@ -45,7 +45,7 @@ async function checkSpaceLinkedToPackageBlock() {
       feedback({ type: 'success', message: `Current Space: ${configstore.get('currentSpaceName')}` })
     }
   }
-  return true
+  return false
 }
 
 async function checkAndSetUserSpacePreference() {

--- a/utils/checkAuth.js
+++ b/utils/checkAuth.js
@@ -15,7 +15,7 @@ const { getShieldSignedInUser } = require('./getSignedInUser')
 
 /**
  * Checks if Shield auth is valid or needs re auth
- * @returns {returnObject}
+ * @returns {Promise<returnObject>}
  */
 async function checkAuth() {
   const redo = { redoShieldAuth: true }
@@ -23,11 +23,11 @@ async function checkAuth() {
   const token = configstore.get('appBlockUserToken', '')
   if (token) {
     try {
-      const user = await getShieldSignedInUser(token)
-      if (user.user === configstore.get('appBlockUserName', '')) {
-        return noredo
+      const { user } = await getShieldSignedInUser(token)
+      if (!user) {
+        return redo
       }
-      return redo
+      return noredo
     } catch (err) {
       console.log(`Something is wrong with shield\n${err}`)
       return redo

--- a/utils/createBlock.js
+++ b/utils/createBlock.js
@@ -50,7 +50,8 @@ async function createBlock(
   // eslint-disable-next-line default-param-last
   isAStandAloneBlock = false,
   jobConfig,
-  metaData
+  metaData,
+  package_block_id
 ) {
   if (arguments.length < 6) throw new Error('NotEnoughArguments in CreateBlock')
 
@@ -214,7 +215,8 @@ async function createBlock(
       visibility === 'PUBLIC',
       sshUrl,
       description,
-      jobConfig
+      jobConfig,
+      package_block_id
     )
   } catch (err) {
     console.log(err.message)

--- a/utils/fileAndFolderHelpers.js
+++ b/utils/fileAndFolderHelpers.js
@@ -203,14 +203,17 @@ function ensureReadMeIsPresent(dir, blockname, showLogs) {
  * @param {String} filePath File path
  * @returns {uploadReadMeReturn}
  */
-async function uploadReadMe(filePath) {
+async function uploadReadMe(filePath, block_id, block_version_id) {
   const result = { status: 'failed', key: '', error: '' }
   try {
     const {
       data: { url, key },
     } = await axios.post(
       appBlockGetPresignedUrlForReadMe,
-      {},
+      {
+        block_id,
+        block_version_id,
+      },
       {
         headers: getShieldHeader(),
       }

--- a/utils/fileAndFolderHelpers.js
+++ b/utils/fileAndFolderHelpers.js
@@ -315,7 +315,7 @@ function isDirEmpty(dirname, ...acceptedItems) {
  * @param {String} dirPath
  * @param {String} destinationPath
  * @param {Array<String>} ignoreList
- * @returns {Array<Record<'oldPath'|'newPath'|'name',String>}
+ * @returns {Promise<Array<Record<'oldPath'|'newPath'|'name',String>>}
  */
 async function prepareFileListForMoving(dirPath, destinationPath, ignoreList) {
   const files = await readdir(dirPath)
@@ -334,7 +334,7 @@ async function prepareFileListForMoving(dirPath, destinationPath, ignoreList) {
  * Moves files.
  * @param {Boolean} muted To mute logs
  * @param {Array<Record<'oldPath'|'newPath'|'name',String>} fileList
- * @return {Array<Record<'status'|'msg'|'newPath'|'oldPath'|'name',String>}
+ * @return {Promise<Array<Record<'status'|'msg'|'newPath'|'oldPath'|'name',String>>}
  */
 async function moveFiles(muted, fileList) {
   const report = []

--- a/utils/locaRegistry/manager.js
+++ b/utils/locaRegistry/manager.js
@@ -129,7 +129,8 @@ class LocalRegistryManager {
     this._checkAndCreateLocalRegistryDir()
 
     const { name, rootPath } = packagedData
-    this.localRegistryData[name] = { rootPath }
+    const curData = this.localRegistryData[name] || {}
+    this.localRegistryData[name] = { ...curData, rootPath }
     this.packagedBlockConfigs[name] = JSON.parse(readFileSync(path.join(rootPath, this.blockConfigFileName)))
 
     this.events.emit('write')

--- a/utils/locaRegistry/manager.js
+++ b/utils/locaRegistry/manager.js
@@ -91,6 +91,37 @@ class LocalRegistryManager {
   }
 
   /**
+   * @param {Object} packagedData  Name, space_id, space_name of packaged block
+   */
+  linkSpaceToPackageBlock(packagedData) {
+    this._checkAndCreateLocalRegistryDir()
+
+    const { name, space_id, space_name } = packagedData
+    const curData = this.localRegistryData[name] || {}
+    this.localRegistryData[name] = { ...curData, space_id, space_name }
+
+    this.events.emit('write')
+  }
+
+  /**
+   * isSpaceLinkedToPackageBlock
+   */
+  isSpaceLinkedToPackageBlock(name, spaceId) {
+    return this.localRegistryData[name]?.space_id === spaceId
+  }
+
+  /**
+   * linkedSpaceOfPackageBlock
+   */
+  linkedSpaceOfPackageBlock(name) {
+    const curData = this.localRegistryData[name]
+    return {
+      space_id: curData.space_id,
+      space_name: curData.space_name,
+    }
+  }
+
+  /**
    * Add new packaged to registry
    * @param {Object} packagedData  Name and RootPath of packaged block
    */

--- a/utils/preActionRunner.js
+++ b/utils/preActionRunner.js
@@ -120,6 +120,17 @@ const preActionChecks = async (actionCommand) => {
       await checkAndSetUserSpacePreference()
       break
 
+    case 'create-version':
+      await ensureUserLogins()
+      await checkAndSetGitConnectionPreference()
+      await checkAndSetUserSpacePreference()
+      break
+
+    case 'publish':
+      await ensureUserLogins()
+      await checkAndSetUserSpacePreference()
+      break
+
     case 'connect':
       if (!isGitInstalled()) {
         console.log('Git not installed')

--- a/utils/registerBlock.js
+++ b/utils/registerBlock.js
@@ -29,7 +29,9 @@ async function registerBlock(
   is_public,
   github_url,
   block_desc,
-  job_config = {}
+  // eslint-disable-next-line default-param-last
+  job_config = {},
+  package_block_id
 ) {
   spinnies.add('register', { text: `Registering ${block_name}` })
 
@@ -40,6 +42,14 @@ async function registerBlock(
     is_public,
     block_desc,
     github_url,
+  }
+
+  if (package_block_id) {
+    postData.package_block_id = package_block_id
+  }
+
+  if (block_type !== 1 && !package_block_id) {
+    throw new Error('Cannot create block without package block')
   }
 
   if (block_type === 7) {

--- a/utils/registryUtils.js
+++ b/utils/registryUtils.js
@@ -57,13 +57,13 @@ const getBlockMetaData = (block_id) =>
     { headers: getShieldHeader() }
   )
 
-const updateReadme = (blockId, key, visibility) =>
+const updateReadme = (blockId, blockVerionId, key) =>
   axios.post(
     appBlockUpdateReadme,
     {
+      block_version_id: blockVerionId,
       block_id: blockId,
       readme_url: key,
-      visibility,
     },
     { headers: getShieldHeader() }
   )

--- a/utils/sync-utils.js
+++ b/utils/sync-utils.js
@@ -12,6 +12,7 @@ const { rename, rm } = require('fs/promises')
 const path = require('path')
 const { configstore } = require('../configstore')
 const create = require('../subcommands/create')
+const { blockTypeInverter } = require('./blockTypeInverter')
 const { CreateError } = require('./errors/createError')
 const { moveFiles, prepareFileListForMoving, ensureDirSync } = require('./fileAndFolderHelpers')
 const { GitManager } = require('./gitmanager')
@@ -43,7 +44,6 @@ const offerAndCreateBlock = async (list) => {
    */
   if (ans) {
     for (let i = 0; i < list.length; i += 1) {
-      console.log(`${i}-I`)
       const ele = list[i]
       report[i] = { oldPath: ele }
       const hasGitFolder = existsSync(path.resolve(ele, '.git'))
@@ -100,11 +100,11 @@ const offerAndCreateBlock = async (list) => {
         try {
           const { clonePath, cloneDirName, blockDetails } = await create(
             blockName,
-            { type: type || null },
+            { type: blockTypeInverter(type) || null, autoRepo: true },
             null,
             true,
             path.resolve(ele, '../'),
-            true
+            false
           )
 
           const newPath = path.join(clonePath, cloneDirName)
@@ -115,7 +115,7 @@ const offerAndCreateBlock = async (list) => {
             registered: true,
             sourcemismatch: false,
             name: blockName,
-            newName: blockName,
+            newName: blockDetails.name,
             data: {
               detailsInRegistry: blockDetails,
               localBlockConfig: blockDetails,


### PR DESCRIPTION
## Fixes
1. *ap-1914*:Package dependecies for shared-fns not installed during start
2. Typo(*ap2024*): *Staring Emulator* -> *Starting Emulator*
3.  Error in space check.. 403 during *init* command
4. typo in sync command code and fix for localregistry undefined error

## Features/workflow changes
1. Switching space within a package context is now restricted
2. Readme is made version dependent
3. **bb sync** will prompt an option to re-register valid blocks ( useful when trying to re-register a copies block code as own block), all blocks with missing ***source.ssh*** will still be picked up for registering. 