### PR TITLE
Init command workflow change

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "semver": "7.3.5",
     "spinnies": "0.5.1",
     "tcp-port-used": "1.0.2",
+    "tree-kill": "^1.2.2",
     "uuid": "8.3.2",
     "winston": "3.3.3",
     "yup": "^0.32.11"

--- a/subcommands/init/index.js
+++ b/subcommands/init/index.js
@@ -18,6 +18,7 @@ const init = async (appblockName, options) => {
   if (useTemplate) await setupTemplate(initializedData)
 
   console.log(chalk.dim(`\ncd ${initializedData.blockFinalName} and start hacking\n`))
+  console.log(chalk.dim(`run bb sync from ${initializedData.blockFinalName} to register templates as new block`))
 }
 
 module.exports = init

--- a/subcommands/init/setupTemplate.js
+++ b/subcommands/init/setupTemplate.js
@@ -5,7 +5,7 @@ const { readFile, writeFile, rename } = require('fs/promises')
 const { readFileSync, writeFileSync, renameSync, readdirSync, statSync } = require('fs')
 
 const { createDirForType, ensureDirSync } = require('../../utils/fileAndFolderHelpers')
-const { wantToCreateNewVersion, wouldLikeToRegisterTemplateBlocksAsNewBlock } = require('../../utils/questionPrompts')
+const { wantToCreateNewVersion } = require('../../utils/questionPrompts')
 const { blockTypeInverter } = require('../../utils/blockTypeInverter')
 const checkBlockNameAvailability = require('../../utils/checkBlockNameAvailability')
 const { checkAndSetGitConfigNameEmail } = require('../../utils/gitCheckUtils')
@@ -17,7 +17,8 @@ const setupTemplate = async (options) => {
   const { DIRPATH, blockFinalName, Git, prefersSsh } = options
 
   const templatesPath = path.join(__dirname, '..', '..', 'templates', 'simple-todo-template')
-  const fastForward = await wouldLikeToRegisterTemplateBlocksAsNewBlock()
+  // const fastForward = await wouldLikeToRegisterTemplateBlocksAsNewBlock()
+  const fastForward = false
 
   ;(async function installDependencies(l, config, relativeDir) {
     const level = l + 1
@@ -280,7 +281,7 @@ const setupTemplate = async (options) => {
 
   // execSync(`npm i -g ${path.join(packagesPath, 'node-block-sdk')}`)
   // console.log('Use block push after changing')
-  console.log('Finished setting up template.')
+  // console.log('Finished setting up template.')
   // await createBlock(componentName, componentName, 'appBlock', '')
 
   process.on('SIGINT', () => {

--- a/subcommands/stop.js
+++ b/subcommands/stop.js
@@ -6,7 +6,7 @@
  */
 
 const chalk = require('chalk')
-const { execSync } = require('child_process')
+const treeKill = require('tree-kill')
 const { stopEmulator } = require('../utils/emulator-manager')
 const { appConfig } = require('../utils/appconfigStore')
 const { sleep } = require('../utils')
@@ -85,7 +85,7 @@ async function stopAllBlock(rootPath) {
     meta: { name },
   } of appConfig.uiBlocks) {
     if (appConfig.isLive(name)) {
-      await stopBlock(name)
+      stopBlock(name)
     }
   }
 
@@ -104,22 +104,21 @@ async function stopAllBlock(rootPath) {
   }
 }
 
-async function stopBlock(name) {
+function stopBlock(name) {
   const liveDetails = appConfig.getLiveDetailsof(name)
   if (liveDetails.isJobOn) {
     console.log('\nLive Job found for this block! Please stop job and try again\n')
     process.exit(1)
   }
-  try {
-    // process.kill(blockToStart.pid, 'SIGKILL')
-    execSync(`pkill -s ${liveDetails.pid}`)
+  treeKill(liveDetails.pid, (err) => {
+    if (err) {
+      console.log('Error in stopping block process with pid ', liveDetails.pid)
+      console.log(err)
+      return
+    }
     appConfig.stopBlock = name
-  } catch (e) {
-    console.log('Error in stopping block process with pid ', liveDetails.pid)
-    console.log(e)
-  }
-
-  console.log(`${name} stopped successfully!`)
+    console.log(`${name} stopped successfully!`)
+  })
 }
 
 module.exports = stop

--- a/utils/noRepo.js
+++ b/utils/noRepo.js
@@ -1,3 +1,4 @@
+const { feedback } = require('./cli-feedback')
 const convertGitSshUrlToHttps = require('./convertGitUrl')
 const { sourceUrlOptions, readInput } = require('./questionPrompts')
 
@@ -12,6 +13,10 @@ async function getRepoUrl() {
   if (o === 1) {
     const s = await readInput({ message: 'Enter source ssh url here', name: 'sUrl' })
     return { ssh: s.trim(), https: convertGitSshUrlToHttps(s.trim()) }
+  }
+  if (o === 0) {
+    feedback({ type: 'error', message: 'Cannot continue without a repo url' })
+    process.exit(1)
   }
   return { ssh: '', https: '' }
 }

--- a/utils/sync-utils.js
+++ b/utils/sync-utils.js
@@ -144,8 +144,8 @@ const offerAndCreateBlock = async (list) => {
             name: blockDetails.name,
             source: blockDetails.source,
           }
-          console.log('newconfig')
-          console.log(newConfig)
+          // console.log('newconfig')
+          // console.log(newConfig)
           console.log(`Writing new config to ${newPath}`)
           writeFileSync(`${newPath}/block.config.json`, JSON.stringify(newConfig))
           // ////////////////////////////////////////


### PR DESCRIPTION
## Fix
1. If **init**,**create** is called with **--no-autoRepo** option, a prompt to provide repo url is shown. on selecting cancel from the prompt, CLI crashed. This is fixed now.
2. **Init** command workflow changed. If templates are to be registered, move to package folder after init finishes and run **sync**

## Feat
1. **tree-kill** package included for windows support in **stop** command

## New Dependencies
1. [tree-kill](https://www.npmjs.com/package/tree-kill)