### PR TITLE
fix: single build start issue

### DIFF
--- a/bin/bb-start.cjs
+++ b/bin/bb-start.cjs
@@ -19,6 +19,7 @@ program
   .argument('[name]', 'Name of block to start')
   .option('--use-pnpm', 'use pnpm to install dependencies')
   .option('--multi-instance', 'multi instance')
+  .option('-bt, --block-type <block-type>', 'Block type to start')
   .action(start)
 
 program.parse(process.argv)

--- a/bin/bb-stop.cjs
+++ b/bin/bb-stop.cjs
@@ -15,6 +15,8 @@ const program = new Command()
 program
   .argument('[name...]', 'Name of block to stop')
   .option('-g, --global', 'execute globally')
+  .option('-h, --hard', 'to regenerate emulator')
+  .option('-bt, --block-type <block-type>', 'Block type to stop')
   .action(stop)
 
 program.parse(process.argv)

--- a/subcommands/languageVersion/util.js
+++ b/subcommands/languageVersion/util.js
@@ -197,9 +197,10 @@ const langVersionsLinkedToAbVersion = async ({ appblockVersionIds, supportedAppb
   if (supportedAppblockVersions) reqBody.appblock_versions = supportedAppblockVersions
   else reqBody.appblock_version_ids = appblockVersionIds
 
-  const { data, error } = await post(listLanguageVersions, reqBody)
+  if (!reqBody.appblock_versions) throw new Error(`No supported appblock versions`)
 
-  if (error) throw new Error(error)
+  const { data, error } = await post(listLanguageVersions, reqBody)
+  if (error) throw error
 
   return data
 }
@@ -275,6 +276,11 @@ const languageVersionCheckCommand = {
 }
 
 const checkLanguageVersionExistInSystem = async ({ supportedAppblockVersions, blockLanguages }) => {
+  if (!supportedAppblockVersions?.length) {
+    console.log(chalk.yellow(`No linked appblock versions found to check language support` ))
+    return []
+  }
+
   spinnies.add('langVersion', { text: `Getting language versions` })
   const langVersionData = await langVersionsLinkedToAbVersion({ supportedAppblockVersions })
   spinnies.remove('langVersion')

--- a/subcommands/start/singleBuild/generateElementsEmulator/generateWebpackConfig.js
+++ b/subcommands/start/singleBuild/generateElementsEmulator/generateWebpackConfig.js
@@ -2,7 +2,7 @@ const generateWebpackConfig = (options) => {
   const { env, emPort, depLib } = options || {}
 
   const rulesRegex = {
-    'babel-loader': /\.jsx?$/,
+    'babel-loader': /\.(js|jsx|ts|tsx)$/,
     'url-loader': /\.(jpg|png|gif|svg|eot|svg|ttf|woff|woff2)$/,
     'style-loader': /\.css$/i,
   }
@@ -16,6 +16,7 @@ import ModuleFederationPlugin from 'webpack/lib/container/ModuleFederationPlugin
 import path from 'path'
 import webpackPkg from 'webpack';
 import exposedJson from './federation-expose.js'
+import sharedJson from './federation-shared.js'
 import * as dotenv from 'dotenv' 
 import { fileURLToPath } from 'url';
 
@@ -57,6 +58,9 @@ const config = {
       {
         test: ${rulesRegex['babel-loader']},
         loader: 'babel-loader',
+        resolve:{
+          fullySpecified:false
+        },
         options: {
           presets: ['@babel/preset-react'],
         },
@@ -88,54 +92,7 @@ const config = {
       },`
           : ''
       }
-      shared: {
-        react: {
-          import: 'react', // the "react" package will be used a provided and fallback module
-          shareKey: 'react', // under this name the shared module will be placed in the share scope
-          shareScope: 'default', // share scope with this name will be used
-          singleton: true, // only a single version of the shared module is allowed
-          requiredVersion: '^18.2.0',
-        },
-        'react-dom': {
-          import: 'react-dom', // the "react" package will be used a provided and fallback module
-          shareKey: 'react-dom', // under this name the shared module will be placed in the share scope
-          shareScope: 'default', // share scope with this name will be used
-          singleton: true, // only a single version of the shared module is allowed
-          requiredVersion: '^18.2.0',
-        },
-        'react-redux': {
-          import: 'react-redux', // the "react" package will be used a provided and fallback module
-          shareKey: 'react-redux', // under this name the shared module will be placed in the share scope
-          shareScope: 'default', // share scope with this name will be used
-          singleton: true, // only a single version of the shared module is allowed
-          version: '^7.2.5',
-        },
-        'react-router-dom': {
-          import: 'react-router-dom',
-          shareKey: 'react-router-dom',
-          shareScope: 'default',
-          singleton: true,
-          version: '^6.9.0',
-        },
-        '@appblocks/js-sdk': {
-          import: '@appblocks/js-sdk',
-          shareKey: '@appblocks/js-sdk',
-          shareScope: 'default',
-          singleton: true,
-          version: '^0.0.11',
-        },
-        'react-query': {
-          import: 'react-query',
-          shareKey: 'react-query',
-          shareScope: 'default',
-          singleton: true,
-          version: '^3.39.2',
-        },
-        "state-pool": {
-          requiredVersion: "^0.8.1",
-          singleton: true, // only a single version of the shared module is allowed
-        },
-      },
+      shared: sharedJson,
     }),
     new HtmlWebpackPlugin({
       template: './public/index.html',

--- a/subcommands/start/singleBuild/index.js
+++ b/subcommands/start/singleBuild/index.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { existsSync, rmSync } = require('fs')
 const path = require('path')
 const { runBash } = require('../../bash')
 const { startBlock } = require('../util')
@@ -34,15 +33,12 @@ const singleBuild = async ({ appConfig, ports, buildOnly = false, env }) => {
     const emEleFolderName = '._ab_em_elements'
     const emEleFolder = path.join(relativePath, emEleFolderName)
 
-    if (existsSync(emEleFolder)) rmSync(emEleFolder, { recursive: true, force: true })
-
     spinnies.update('singleBuild', { text: `Generating elements emulator` })
     await generateElementsEmulator(emEleFolder, { emPort: emElPort, depLib })
 
     spinnies.update('singleBuild', { text: `Merging elements` })
     const errorBlocks = await mergeDatas(elementBlocks, emEleFolder, depLib, env)
 
-    spinnies.update('singleBuild', { text: `Installing dependencies for elements emulator` })
     await packageInstall(emEleFolder, elementBlocks)
 
     if (buildOnly) {

--- a/subcommands/start/singleBuild/util.js
+++ b/subcommands/start/singleBuild/util.js
@@ -67,7 +67,7 @@ const packageInstall = async (emEleFolder, elementBlocks) => {
 
     spinnies.update('singleBuild', { text: `Installing dependencies for elements emulator (${installer})` })
 
-    const res = await pexec(`cd ${emEleFolder} && ${installer}`, { cwd: emEleFolder })
+    const res = await pexec(installer, { cwd: emEleFolder })
     if (res.err) throw new Error(res.err)
 
     for (const block of elementBlocks) {

--- a/subcommands/start/singleBuild/util.js
+++ b/subcommands/start/singleBuild/util.js
@@ -3,11 +3,13 @@ const { promisify } = require('util')
 const treeKill = require('tree-kill')
 const isRunning = require('is-running')
 const { symlink } = require('fs/promises')
-const { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } = require('fs')
+const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs')
 const { createFileSync } = require('../../../utils/fileAndFolderHelpers')
 const { runBashLongRunning, runBash } = require('../../bash')
 const { checkPnpm } = require('../../../utils/pnpmUtils')
 const { pexec } = require('../../../utils/execPromise')
+const { configstore } = require('../../../configstore')
+const { spinnies } = require('../../../loader')
 
 const emulateElements = async (emEleFolder, port) => {
   const logOutPath = path.resolve('./logs/out/elements.log')
@@ -31,7 +33,7 @@ const emulateElements = async (emEleFolder, port) => {
 }
 
 async function stopEmulatedElements(options) {
-  const { rootPath = '.' } = options
+  const { rootPath = '.', hard } = options
 
   const emPath = path.join(rootPath, '._ab_em_elements')
   const emConfigPath = path.join(emPath, '.emconfig.json')
@@ -49,7 +51,8 @@ async function stopEmulatedElements(options) {
     }
   }
 
-  if (existsSync(emPath)) {
+  if (hard && existsSync(emPath)) {
+    console.log({ hard })
     await runBash(`rm -rf ${emPath}`)
   }
 }
@@ -59,31 +62,41 @@ const packageInstall = async (emEleFolder, elementBlocks) => {
     const src = path.join(emEleFolder, 'node_modules')
 
     let installer = 'npm i'
-    if (global.usePnpm || checkPnpm()) installer = 'pnpm i'
+    const nodePackageManager = configstore.get('nodePackageManager')
+    if (global.usePnpm || (!nodePackageManager && checkPnpm())) installer = 'pnpm i'
+
+    spinnies.update('singleBuild', { text: `Installing dependencies for elements emulator (${installer})` })
+
     const res = await pexec(`cd ${emEleFolder} && ${installer}`, { cwd: emEleFolder })
     if (res.err) throw new Error(res.err)
 
-    await Promise.all(
-      elementBlocks.map(async (bk) => {
-        const dest = path.resolve(bk.directory, 'node_modules')
-
-        try {
-          rmSync(dest, { recursive: true, force: true })
-        } catch (e) {
-          // nothing
-        }
-
+    for (const block of elementBlocks) {
+      const dest = path.resolve(block.directory, 'node_modules')
+      try {
+        // rmSync(dest, { recursive: true, force: true })
         await symlink(src, dest)
-      })
-    )
+      } catch (e) {
+        // nothing
+      }
+    }
   } catch (e) {
     console.log(`Error in install dependencies: `, e.message)
     throw e
   }
 }
 
+const getModuleFederationPluginShared = async (directory) => {
+  const sharedFed = path.resolve(directory, 'federation-shared.js')
+  if (!existsSync(sharedFed)) return {}
+  const webpackShared = await import(sharedFed)
+  const webpackSharedJs = webpackShared.default || {}
+  if (webpackShared) return webpackSharedJs
+  return {}
+}
+
 module.exports = {
   emulateElements,
   stopEmulatedElements,
   packageInstall,
+  getModuleFederationPluginShared,
 }

--- a/subcommands/start/util.js
+++ b/subcommands/start/util.js
@@ -112,9 +112,6 @@ async function startJsProgram(block, name, port) {
     const directory = getAbsPath(block.directory)
     spinnies.update(name, { text: `Installing dependencies in ${name}` })
 
-    const nodeModulePath = path.join(directory, 'node_modules')
-    removeSync([nodeModulePath])
-
     // const i = await runBash(block.meta.postPull, directory)
     const i = await runBash(global.usePnpm ? 'pnpm install' : block.meta.postPull, path.resolve(block.directory))
     if (i.status === 'failed') {

--- a/subcommands/startV2/plugins/fnEmulatorPlugins/buildNodeFnEmulator.js
+++ b/subcommands/startV2/plugins/fnEmulatorPlugins/buildNodeFnEmulator.js
@@ -191,8 +191,8 @@ class BuildNodeFnEmulator {
         const directory = path.resolve(dir)
         try {
           const packages = await JSON.parse(readFileSync(path.join(directory, 'package.json')).toString())
-          mergedPackages.dependencies = { ...mergedPackages.dependencies, [name]: packages.dependencies }
-          mergedPackages.devDependencies = { ...mergedPackages.devDependencies, [name]: packages.devDependencies }
+          mergedPackages.dependencies = { ...mergedPackages.dependencies, [name]: packages?.dependencies || {} }
+          mergedPackages.devDependencies = { ...mergedPackages.devDependencies, [name]: packages?.devDependencies || {} }
         } catch (error) {
           console.error(`${error.message} on block ${name}`)
         }

--- a/subcommands/upload/index.js
+++ b/subcommands/upload/index.js
@@ -74,6 +74,7 @@ const upload = async (blockName, options) => {
       })
     }
   } catch (error) {
+    console.log(error);
     spinnies.fail('up', { text: 'Error checking app data' })
     process.exit(1)
   }

--- a/subcommands/upload/onPrem/awsECR/util.js
+++ b/subcommands/upload/onPrem/awsECR/util.js
@@ -5,7 +5,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const { writeFileSync, readFileSync, existsSync, rmSync } = require('fs')
+const { writeFileSync, readFileSync, existsSync } = require('fs')
 const path = require('path')
 const { configstore } = require('../../../../configstore')
 const { spinnies } = require('../../../../loader')
@@ -94,6 +94,18 @@ const getAWSECRConfig = async (options) => {
   return { container }
 }
 
+const emPackageInstall = async (emulatorPath) => {
+  let installer = 'npm i'
+  const nodePackageManager = configstore.get('nodePackageManager')
+  global.usePnpm = nodePackageManager === 'pnpm' || (!nodePackageManager && checkPnpm())
+  if (global.usePnpm) installer = 'pnpm i'
+
+  spinnies.add('singleBuild', { text: `Installing dependencies for emulator (${installer})` })
+  const i = await pexec(installer, { cwd: emulatorPath })
+  if (i.err) throw new Error(i.err)
+  spinnies.remove('singleBuild')
+}
+
 const updateEmulatorPackageSingleBuild = async ({ dependencies, emulatorPath }) => {
   const emulatorPackageJsonPath = path.join(emulatorPath, 'package.json')
   const emulatorPackageJson = await JSON.parse(readFileSync(path.resolve(emulatorPackageJsonPath)).toString())
@@ -102,41 +114,26 @@ const updateEmulatorPackageSingleBuild = async ({ dependencies, emulatorPath }) 
     dependencies: { em: emulatorPackageJson.dependencies || {} },
     devDependencies: { em: emulatorPackageJson.devDependencies || {} },
   }
+  for (const block of Object.values(dependencies)) {
+    const {
+      meta: { name },
+      directory: dir,
+    } = block
+    const directory = path.resolve(dir)
 
-  await Promise.all(
-    Object.values(dependencies).map(async (bk) => {
-      const {
-        meta: { name },
-        directory: dir,
-      } = bk
-      const directory = path.resolve(dir)
-
-      try {
-        const packages = await JSON.parse(readFileSync(path.join(directory, 'package.json')).toString())
-        mergedPackages.dependencies = { ...mergedPackages.dependencies, [name]: packages.dependencies }
-        mergedPackages.devDependencies = { ...mergedPackages.devDependencies, [name]: packages.devDependencies }
-      } catch (error) {
-        console.log(`Error reading package.json for block ${name} : ${error.message}`)
-      }
-    })
-  )
+    try {
+      const packages = await JSON.parse(readFileSync(path.join(directory, 'package.json'), 'utf-8'))
+      mergedPackages.dependencies = { ...mergedPackages.dependencies, [name]: packages?.dependencies || {} }
+      mergedPackages.devDependencies = { ...mergedPackages.devDependencies, [name]: packages?.devDependencies || {} }
+    } catch (error) {
+      console.log(`Error reading package.json for block ${name} : ${error.message}`)
+    }
+  }
 
   emulatorPackageJson.dependencies = updatePackageVersionIfNeeded(mergedPackages.dependencies)
   emulatorPackageJson.devDependencies = updatePackageVersionIfNeeded(mergedPackages.devDependencies)
 
   writeFileSync(emulatorPackageJsonPath, JSON.stringify(emulatorPackageJson, null, 2))
-
-  const modulesPath = path.join(emulatorPath, 'node_modules')
-  if (existsSync(modulesPath)) rmSync(modulesPath, { recursive: true })
-
-  let installer = 'npm i'
-  const nodePackageManager = configstore.get('nodePackageManager')
-  global.usePnpm = nodePackageManager === 'pnpm' || checkPnpm()
-  if (global.usePnpm) installer = 'pnpm i'
-  spinnies.add('singleBuild', { text: `Installing dependencies for emulator (${installer})` })
-  const i = await pexec(`cd ${emulatorPath} && ${installer}`)
-  if (i.err) throw new Error(i.err)
-  spinnies.remove('singleBuild')
 }
 
 const generateDockerFileSingleBuild = ({ ports, dependencies, version, env, config }) => {
@@ -187,32 +184,29 @@ CMD ["pm2-runtime", "._ab_em/index.js", "-i max"]
   writeFileSync('./Dockerfile', fileData)
 }
 
+
+
+
 const setSymlinkCode = async (dependencies, emulatorPath) => {
-  const dependenciesData = Object.values(dependencies)
+  const dependenciesDirectories = Object.values(dependencies).map(({directory}) => directory)
 
   const setSymlinkCodeData = `
 import { symlink } from 'fs/promises'
-import { rmSync } from 'fs'
 import path from 'path'
 
 const src = path.resolve('node_modules')
-const dependencies = ${JSON.stringify(dependenciesData)}
+const dependenciesDirectories = ${JSON.stringify(dependenciesDirectories)}
 
-await Promise.all(
-  dependencies.map(async (bk) => {
-    const dest = path.resolve('..', bk.directory, 'node_modules')
-
-    try {
-      rmSync(dest, { recursive: true, force: true })
-    } catch (e) {
-      // nothing
-    }
-
+for (const dir of dependenciesDirectories) {
+  const dest = path.resolve('..', dir, 'node_modules')
+  try {
     await symlink(src, dest)
-  })
-)
+  } catch (e) {
+    // nothing
+  }
+}
 `
-  writeFileSync(path.join(emulatorPath, 'setSymlink.js'), setSymlinkCodeData)
+  writeFileSync(path.join(emulatorPath, 'setSymlink.js'), setSymlinkCodeData.trim())
 }
 
 const generateDockerIgnoreFileSingleBuild = (dependencies, config) => {
@@ -230,6 +224,7 @@ const beSingleBuildDeployment = async ({ container_ports, dependencies, env, con
   await copyEmulatorCode(container_ports, dependencies)
   await setSymlinkCode(dependencies, emulatorPath)
   await updateEmulatorPackageSingleBuild({ dependencies, emulatorPath })
+  await emPackageInstall(emulatorPath)
   generateDockerIgnoreFileSingleBuild(dependencies, config)
   generateDockerFileSingleBuild({ ports: container_ports, dependencies, env, config })
 }
@@ -240,4 +235,5 @@ module.exports = {
   getAWSECRConfig,
   beSingleBuildDeployment,
   updateEmulatorPackageSingleBuild,
+  emPackageInstall,
 }

--- a/utils/emulator-manager.js
+++ b/utils/emulator-manager.js
@@ -42,9 +42,6 @@ async function copyEmulatorCode(PORTS, dependencies) {
   import express from "express";
   import http from "http";
   import cors from "cors";
-  import { readFile } from "fs/promises";
-  import swaggerUi from "swagger-ui-express";
-  import swaggerJSDoc from "swagger-jsdoc";
   import fs from "fs"
   
   const appHandler = (type) => async (req, res, next) => {
@@ -93,29 +90,6 @@ async function copyEmulatorCode(PORTS, dependencies) {
   
   for (const [bt, port] of ${JSON.stringify(emulatorDataEntries)}) {
       const app = express();
-      
-      const OpenApiDocfilePath = "../";
-      const apis=[]
-    
-      fs.readdirSync(OpenApiDocfilePath).forEach(file=>{
-        let filePath ="../" + file + "/*.js";
-        apis.push(filePath)
-      })
-          
-      const options = {
-        definition: {
-          openapi: '3.0.0',
-          info: {
-            title: 'Api Doc',
-            version: '1.0.0',
-          },
-        },
-        apis: apis, // files containing annotations as above
-      };
-
-      const openapiSpecification = swaggerJSDoc(options)
-
-      app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(openapiSpecification));
       app.use(cors());
       app.all("/*", appHandler(bt));
       const server = http.createServer(app);
@@ -249,7 +223,7 @@ function addEmulatorProcessData(processData) {
   fs.writeFileSync('./._ab_em/.emconfig.json', JSON.stringify(processData))
 }
 
-async function stopEmulator(rootPath) {
+async function stopEmulator(rootPath, hard) {
   // if (localRegistry) {
   //   await Promise.all(
   //     Object.entries(localRegistry).map(async ([k, { rootPath }]) => {
@@ -272,7 +246,7 @@ async function stopEmulator(rootPath) {
       await runBash(`kill ${processData.pid}`)
     }
 
-    await runBash(`rm -rf ${path.join(rootPath, '._ab_em')}`)
+    if (hard) await runBash(`rm -rf ${path.join(rootPath, '._ab_em')}`)
     console.log('emulator stopped successfully!')
   }
   // }


### PR DESCRIPTION
# Fix for  single build for backend

 This PR includes hot fixes for, missing shared blocks & runtime errors from the program on `bb start`.
- `npm` will be the  preferred package manager, until symlink issue with `pnpm` is resolved.
- Both emulator folder will not be removed on `bb stop`, to reduce installation time with npm.
- Remove hard-coded ModuleFederationShared and read federation-shared.js 

## Note to users
- `bb start -bt function` && `bb start -bt ui` commands can be used to start  _function_ & _view_ blocks indepdently.
- **USER MUST UPDATE `node-sdk` to version `0.0.5`**
- **USER MUST CREATE a file named _headless-config.json_ with key _prismaSchemaFolderPath_ & value must be the ABSOLUTE path to the shared prisma block's prisma schema**
- **USER MUST CREATE a _federation-shared.js_ file inside any of the `ui-elements` type block, if user wants any libraries to be shared by federated blocks**
