### PR TITLE
fix: single build inconsistancy

### DIFF
--- a/subcommands/deploy/onPrem/awsFargate/util.js
+++ b/subcommands/deploy/onPrem/awsFargate/util.js
@@ -37,17 +37,6 @@ const CPU_MEMORY_COMBINATIONS = [
 ]
 
 const getAWSFargateConfig = async () => {
-  const sBDeployment = await readInput({
-    type: 'list',
-    name: 'sBDeployment',
-    message: 'Select the build process type',
-    choices: [
-      { name: 'Single Build', value: true },
-      { name: 'Normal Build', value: false },
-    ],
-    default: true,
-  })
-
   spinnies.add('vpcGet', { text: 'Getting vpcs' })
   const vpcs = await ec2Handler.describeVpcs()
   spinnies.remove('vpcGet')

--- a/subcommands/deploy/onPrem/awsFargate/util.js
+++ b/subcommands/deploy/onPrem/awsFargate/util.js
@@ -118,8 +118,7 @@ const getAWSFargateConfig = async () => {
     securityGroupIds,
     memory,
     cpu,
-    autoScaleAllowed,
-    singleBuildDeployment: sBDeployment,
+    autoScaleAllowed
   }
 
   if (autoScaleAllowed) {

--- a/subcommands/deploy/onPrem/util.js
+++ b/subcommands/deploy/onPrem/util.js
@@ -139,20 +139,18 @@
      })
    }
  
-   if (blockType === 'view') {
-     sBDeployment = await readInput({
-       type: 'list',
-       name: 'sBDeployment',
-       message: 'Select the build process type',
-       choices: [
-         { name: 'Single Build', value: true },
-         { name: 'Normal Build', value: false },
-       ],
-       default: true,
-     })
-   }
+    sBDeployment = await readInput({
+      type: 'list',
+      name: 'sBDeployment',
+      message: 'Select the build process type',
+      choices: [
+        { name: 'Single Build', value: true },
+        { name: 'Normal Build', value: false },
+      ],
+      default: true,
+    })
  
-   if (sBDeployment && !opdEleDomain) {
+   if (sBDeployment && !opdEleDomain && blockType === 'view') {
      opdEleDomain = await readInput({
        name: 'domain',
        message: `Enter domain name of views elements deploy (single build)`,


### PR DESCRIPTION
Removed the code block which allows the user to choose the build type from `getAWSFargateConfig`.
`getAWSFargateConfig` was responsible for writing the `singleBuildDeployment` inside `aws_fargate`.
```json
"aws_fargate": {
      "vpcId": "vpc-blaaahh",
      "subnetIds": [
        "subnet-blaaahh",
      ],
      "securityGroupIds": [
        "sg-blaaahh"
      ],
      "memory": "1 GB",
      "cpu": ".5 vCPU",
      "autoScaleAllowed": true,
      "singleBuildDeployment": true,
      "minCapacity": 1,
      "maxCapacity": 2,
      "desiredCount": 2
    }
```
but when reading the config, the cli was looking for `singleBuildDeployment` outside the `aws_fargate`.

So I removed a condition in `getOnPremConfigDetails` function which restricted the choice of `singleBuildDeployment` for only blocks of type `view`.

This should hopefully fix the issue.