### PR TITLE
fix: s3 bucket policy update and docker build

### DIFF
--- a/bin/bb.cjs
+++ b/bin/bb.cjs
@@ -104,6 +104,8 @@ cmd('update-language-version', 'update block language version')
 
 cmd('use', 'to select space')
 
+cmd('set-appblock-version', 'To add supported version of appblock to block')
+
 /**
  * PRIVATE FEATURES
  */

--- a/subcommands/upload/onPrem/awsECR/index.js
+++ b/subcommands/upload/onPrem/awsECR/index.js
@@ -9,7 +9,7 @@ const { spinnies } = require('../../../../loader')
 const { ecrHandler } = require('../../../../utils/aws/ecr')
 const { getBBConfig } = require('../../../../utils/config-manager')
 const { copyEmulatorCode } = require('../../../../utils/emulator-manager')
-const { generateRootPackageJsonFile, generateDockerFile, beSingleBuildDeployment } = require('./util')
+const { generateRootPackageJsonFile, generateDockerFile, beSingleBuildDeployment, generateDockerIgnoreFile } = require('./util')
 
 const onPremECRUpload = async (options) => {
   const { appData, envData, config, deployConfigManager } = options
@@ -47,6 +47,7 @@ const onPremECRUpload = async (options) => {
     } else {
       await copyEmulatorCode(container_ports, dependencies)
       generateRootPackageJsonFile({ appName, dependencies })
+      generateDockerIgnoreFile(dependencies, config)
       generateDockerFile({ ports: container_ports, dependencies, envName, config })
     }
 

--- a/subcommands/upload/onPrem/awsS3/index.js
+++ b/subcommands/upload/onPrem/awsS3/index.js
@@ -48,7 +48,8 @@ const onPremS3Upload = async (options) => {
     })
 
     if (config.singleBuildDeployment) {
-      await singleBuildDeployment({ deployConfigManager, deployedData, config, opdBackupFolder, env: envName })
+      const backendUrl = envData.on_premise?.backend?.aws_fargate?.[0]?.load_balancer_dns
+      await singleBuildDeployment({ deployConfigManager, config, opdBackupFolder, env: envName, backendUrl })
       return
     }
 

--- a/utils/aws/ecr/index.js
+++ b/utils/aws/ecr/index.js
@@ -87,8 +87,7 @@ class ECR_Handler {
         await execSync(`docker save ${containerName} > ${backupFolder}/${containerName}.tar`)
       }
 
-      await runBash('rm -rf ./._ab_em && rm ./Dockerfile && rm .dockerignore')
-      await runBash('rm ./package.json && rm ./package-lock.json')
+      await runBash('rm ./Dockerfile .dockerignore ./package.json ./package-lock.json')
       spinnies.succeed('upimg', { text: `Image uploads completed successfully` })
       return { uploaded: true }
     } catch (error) {

--- a/utils/env.js
+++ b/utils/env.js
@@ -11,12 +11,22 @@ const path = require('path')
 const fs = require('fs')
 const fsPromise = require('fs/promises')
 
-const convertToEnv = (object, existingValue) => {
-  return Object.entries(object).reduce((acc, [key, value]) => {
+const convertToEnv = (envObject, existingValue) => {
+  let existingObject = {}
+  if (existingValue && typeof existingValue === 'string') {
+    existingObject = existingValue.split('\n').reduce((a, eData) => {
+      const [key, value] = eData.split('=')
+      if (!key?.length) return a
+      return { ...a, [key]: value }
+    }, {})
+  }
+  const newEnvObject = { ...existingObject, ...envObject }
+
+  return Object.entries(newEnvObject).reduce((acc, [key, value]) => {
     // eslint-disable-next-line no-param-reassign
     acc += `${key}=${value}\n`
     return acc
-  }, existingValue || '')
+  }, '')
 }
 
 const upsertEnv = async (envPath, envData) => {

--- a/utils/nodePackageManager.js
+++ b/utils/nodePackageManager.js
@@ -1,0 +1,24 @@
+const { configstore } = require('../configstore')
+const { checkPnpm } = require('./pnpmUtils')
+
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const getNodePackageInstaller = () => {
+  let installer = 'npm i'
+  const nodePackageManager = configstore.get('nodePackageManager')
+  global.usePnpm = nodePackageManager === 'pnpm' || (!nodePackageManager && checkPnpm())
+  if (global.usePnpm) installer = 'pnpm i'
+
+  let installPackage = ''
+  if (nodePackageManager === 'pnpm') {
+    installPackage = 'npm install -g pnpm'
+  }
+
+  return { installer, nodePackageManager, installPackage }
+}
+
+module.exports = { getNodePackageInstaller }


### PR DESCRIPTION

# Fix for Single Build Deployment

This pull request includes hot fixes for two issues:

1. `s3` bucket creation issue
2. Copying `node_modules` to `docker` issue

## `s3` Bucket Creation Issue

As explained in this [Stack Overflow answer](https://stackoverflow.com/a/76110289/12650528), Amazon S3 changed the default settings for S3 Block Public Access and Object Ownership (ACLs disabled) for all new S3 buckets starting in April 2023. For new buckets created after this update, all S3 Block Public Access settings are enabled, and S3 access control lists (ACLs) are disabled. Due to this change, the create bucket command while uploading to an `s3` bucket was failing.

To fix this issue, we updated the bucket public access after creating the bucket without ACL.

## Copying `node_modules` to `docker` Issue

The issue we faced here was related to copying `node_modules` to `docker` on an operating system like Mac, where some dependencies like `bcrypt` build on `npm install` based on the underlying OS. This caused issues with dependencies that were built on a different OS than the one being used for the deployment.

To solve this issue, we decided to install the packages inside the `docker` container to ensure that they are built on the same OS as the container. This ensured that the dependencies were built correctly and the issue was resolved.

Overall, these fixes ensure that our single build deployment process runs smoothly and without any issues.