### PR TITLE
feat:  linear command for upload and deploy

### DIFF
--- a/bin/bb-deploy.cjs
+++ b/bin/bb-deploy.cjs
@@ -16,6 +16,7 @@ program
   .option('-rv, --release-version <release_version>', 'version number')
   .option('-rn, --release-note <release_note>', 'release note')
   .option('-env, --environment <environment>', 'environment')
+  .option('-cn, --config-name <config-name>', 'Name of the configuration')
   .action(deploy)
 
 program.parse(process.argv)

--- a/bin/bb-log-v2.cjs
+++ b/bin/bb-log-v2.cjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { Command } = require('commander')
+const log = require('../subcommands/logV2')
+
+const program = new Command()
+
+program
+  .argument('[block-name]', 'Name of a live block')
+  .option('-e,--err', 'Watch error logs')
+  .option('-o,--out', 'Watch out logs')
+  .action(log)
+
+program.parse(process.argv)

--- a/bin/bb-pull-v2.cjs
+++ b/bin/bb-pull-v2.cjs
@@ -13,7 +13,7 @@ const checkAndSetGitConnectionPreference = require('../utils/checkAndSetGitConne
 const checkAndSetUserSpacePreference = require('../utils/checkAndSetUserSpacePreference')
 const { ensureUserLogins } = require('../utils/ensureUserLogins')
 const { isGitInstalled } = require('../utils/gitCheckUtils')
-const pull = require('../subcommands/pull')
+const pull = require('../subcommands/pullV2')
 
 const program = new Command().hook('preAction', async () => {
   if (!isGitInstalled()) {
@@ -27,7 +27,7 @@ const program = new Command().hook('preAction', async () => {
 })
 
 program
-  .argument('<component>', 'Name of component with version. block@0.0.1')
+  .argument('[component]', 'Name of component with version. (eg: @[spaceName]/[blockName]@[version])')
   .option('--add-variant', 'Add as variant')
   .option('--no-variant', 'No variant')
   .option('-t, --type <variantType>', 'Type of variant to create')

--- a/bin/bb-upload.cjs
+++ b/bin/bb-upload.cjs
@@ -14,7 +14,8 @@ const program = new Command()
 
 program
   .argument('[block]', 'name of block or block type')
-  .requiredOption('-env, --environment <environment>', 'environment')
+  .option('-env, --environment <environment>', 'environment')
+  .option('-cn, --config-name <config-name>', 'Name of the configuration')
   .action(upload)
 
 program.parse(process.argv)

--- a/bin/bb.cjs
+++ b/bin/bb.cjs
@@ -60,6 +60,8 @@ cmd('list-language-version', 'list block language version')
 
 cmd('log', 'Streams the logs of a live block')
 
+cmd('log-v2', 'Streams the logs of a live block')
+
 cmd('login', 'to log in to shield')
 
 cmd('logout', 'to logout of shield')

--- a/bin/bb.cjs
+++ b/bin/bb.cjs
@@ -74,6 +74,8 @@ cmd('publish', 'Publish block or appblock')
 
 cmd('pull', 'to pull blocks')
 
+cmd('pull-v2', 'to pull blocks')
+
 cmd('push', 'To commit and push blocks')
 
 cmd('push-v2', 'To commit and push blocks')

--- a/subcommands/createV2/plugins/handleMultiRepo.js
+++ b/subcommands/createV2/plugins/handleMultiRepo.js
@@ -1,8 +1,5 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable class-methods-use-this */
-const { renameSync } = require('fs')
-const path = require('path')
-const createBlockV2 = require('../../../utils/createBlockV2')
 // eslint-disable-next-line no-unused-vars
 const CreateCore = require('../createCore')
 
@@ -18,33 +15,33 @@ class handleMultiRepo {
         /**
          * @type {CreateCore}
          */
-        core
+        // core
       ) => {
-        if (core.repoType !== 'multi') return
+        // if (core.repoType !== 'multi') return
 
-        const { type, createFromExistingURL } = core.cmdOpts
-        const { blockName } = core.cmdArgs
+        // const { type, createFromExistingURL } = core.cmdOpts
+        // const { blockName } = core.cmdArgs
 
-        const { blockSource, blockFinalName } = await createBlockV2({
-          cwd: core.cwd,
-          blockTypeNo: type,
-          blockName,
-          createFromExistingURL,
-        })
+        // const { blockSource, blockFinalName } = await createBlockV2({
+        //   cwd: core.cwd,
+        //   blockTypeNo: type,
+        //   blockName,
+        //   createFromExistingURL,
+        // })
 
-        if (blockName !== blockFinalName) {
-          core.cmdArgs.blockName = blockFinalName
-          const newFolderPath = path.join(core.cwd, blockFinalName)
-          await renameSync(core.blockFolderPath, newFolderPath)
-          core.blockFolderPath = newFolderPath
-          core.blockConfigPath = path.join(core.blockFolderPath, 'block.config.json')
-        }
+        // if (blockName !== blockFinalName) {
+        //   core.cmdArgs.blockName = blockFinalName
+        //   const newFolderPath = path.join(core.cwd, blockFinalName)
+        //   await renameSync(core.blockFolderPath, newFolderPath)
+        //   core.blockFolderPath = newFolderPath
+        //   core.blockConfigPath = path.join(core.blockFolderPath, 'block.config.json')
+        // }
 
-        core.blockDetails = {
-          ...core.blockDetails,
-          name: blockFinalName,
-          source: blockSource,
-        }
+        // core.blockDetails = {
+        //   ...core.blockDetails,
+        //   name: blockFinalName,
+        //   source: blockSource,
+        // }
       }
     )
   }

--- a/subcommands/deploy/abPrem/index.js
+++ b/subcommands/deploy/abPrem/index.js
@@ -12,9 +12,9 @@ const { readInput } = require('../../../utils/questionPrompts')
 
 const { spinnies } = require('../../../loader')
 
-const abPremDeploy = async ({ argOpitons, deployConfigManager }) => {
+const abPremDeploy = async ({ argOptions, deployConfigManager }) => {
   const appData = deployConfigManager.deployAppConfig
-  const { releaseVersion, releaseNote } = argOpitons
+  const { releaseVersion, releaseNote } = argOptions
 
   const deployableData = Object.values(appData.environments).reduce((acc, envData) => {
     if (envData.uploads) {

--- a/subcommands/deploy/index.js
+++ b/subcommands/deploy/index.js
@@ -12,30 +12,37 @@ const abPremDeploy = require('./abPrem')
 const onPremDeploy = require('./onPrem')
 
 const deploy = async (options) => {
-  await deployConfigManager.init()
+  try {
+    await deployConfigManager.init()
 
-  const appData = deployConfigManager.deployAppConfig
+    const appData = deployConfigManager.deployAppConfig
 
-  if (!appData?.app_id) {
-    console.log(chalk.red(`Deploy app does not exist. Please create-app and try again\n`))
-    process.exit(1)
-  }
+    if (!appData?.app_id) {
+      console.log(chalk.red(`Deploy app does not exist. Please create-app and try again\n`))
+      process.exit(1)
+    }
 
-  const deployMethodType = await readInput({
-    type: 'list',
-    name: 'deployId',
-    message: 'Select the deployment server',
-    choices: [
-      { name: 'On-Premise', value: 0 },
-      { name: 'Appblocks-Premise (coming soon)', value: 1, disabled: true },
-    ],
-    default: 0,
-  })
+    let deployMethodType = 0
+    if (!options.configName) {
+      deployMethodType = await readInput({
+        type: 'list',
+        name: 'deployId',
+        message: 'Select the deployment server',
+        choices: [
+          { name: 'On-Premise', value: 0 },
+          { name: 'Appblocks-Premise (coming soon)', value: 1, disabled: true },
+        ],
+        default: 0,
+      })
+    }
 
-  if (deployMethodType === 0) {
-    await onPremDeploy({ argOpitons: options, appData, deployConfigManager })
-  } else {
-    await abPremDeploy({ argOpitons: options, appData, deployConfigManager })
+    if (deployMethodType === 0) {
+      await onPremDeploy({ argOptions: options, appData, deployConfigManager })
+    } else {
+      await abPremDeploy({ argOptions: options, appData, deployConfigManager })
+    }
+  } catch (error) {
+    console.log(chalk.red(error.message))
   }
 }
 

--- a/subcommands/deploy/manager.js
+++ b/subcommands/deploy/manager.js
@@ -27,7 +27,7 @@ class DeployblockConfigManager {
 
   async syncOnPremDeploymentConfig(options) {
     let onPremDeployConfig = await this.readOnPremDeployConfig
-    if (!isEmptyObject(onPremDeployConfig)) return onPremDeployConfig
+    if (!isEmptyObject(onPremDeployConfig) || options.configName) return onPremDeployConfig
 
     onPremDeployConfig = await getOnPremConfigDetails(options)
     this.writeOnPremDeployConfig({

--- a/subcommands/logV2/index.js
+++ b/subcommands/logV2/index.js
@@ -1,0 +1,97 @@
+/* eslint-disable no-param-reassign */
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const chalk = require('chalk')
+const { existsSync, createReadStream, watchFile } = require('fs')
+const path = require('path')
+const { appConfig } = require('../../utils/appconfigStore')
+
+const log = async (blockName, { err, out }) => {
+  await appConfig.init()
+  if (appConfig.isInBlockContext && !appConfig.isInAppblockContext) {
+    blockName = appConfig.allBlockNames.next().value
+  }
+
+  const logOutRoot = path.resolve('logs', 'out')
+  const fnOutLogs = path.join(logOutRoot, 'functions.log')
+  const eleOutLogs = path.join(logOutRoot, 'elements.log')
+
+  const logErrRoot = path.resolve('logs', 'err')
+  const fnErrLogs = path.join(logErrRoot, 'functions.log')
+  const eleErrLogs = path.join(logErrRoot, 'elements.log')
+
+  const filesToWatch = []
+
+  if (blockName) {
+    if (!appConfig.has(blockName)) {
+      console.log(`Block doesn't exist`)
+      return
+    }
+    if (!appConfig.isLive(blockName)) {
+      console.log(`${blockName} is not live.`)
+      console.log(`Run bb start ${blockName} to start the block.`)
+      return
+    }
+
+    console.log(`Showing log of ${blockName}`)
+    const appLiveData = appConfig.getBlockWithLive(blockName)
+    const logOutPath = appLiveData.meta.type === 'function' ? fnOutLogs : appLiveData.log.out
+    const logErrPath = appLiveData.meta.type === 'function' ? fnErrLogs : appLiveData.log.err
+
+    if (err) {
+      filesToWatch.push(logErrPath)
+    }
+    if (out) {
+      filesToWatch.push(logErrPath)
+    }
+
+    if (!err && !out) {
+      filesToWatch.push(logOutPath, logErrPath)
+    }
+  } else {
+    const containerData = [...appConfig.uiBlocks].find(({ meta }) => meta.type === 'ui-container')
+    const containerLiveData = appConfig.getBlockWithLive(containerData?.meta?.name)
+
+    if (err) {
+      if (containerLiveData?.log) filesToWatch.push(containerLiveData.log.err)
+      filesToWatch.push(fnOutLogs, eleOutLogs, fnErrLogs, eleErrLogs)
+    }
+    if (out) {
+      if (containerLiveData?.log) filesToWatch.push(containerLiveData.log.out)
+      filesToWatch.push(fnOutLogs, eleOutLogs, fnErrLogs, eleErrLogs)
+    }
+    if (!err && !out) {
+      if (containerLiveData?.log) filesToWatch.push(containerLiveData.log.err, containerLiveData.log.out)
+      filesToWatch.push(fnOutLogs, eleOutLogs, fnErrLogs, eleErrLogs)
+    }
+  }
+
+  const readLog = (logPath, start, end) => {
+    const stream = createReadStream(logPath, { encoding: 'utf8', autoClose: false, start, end })
+    stream.on('data', (d) => {
+      const logType = logPath.includes('/err/') ? 'Error' : 'Log'
+      const logMsg = `${new Date().toLocaleString()} - ${path.basename(logPath)} - ${logType}: ${d}`
+      if (logType === 'Error') console.log(chalk.red(logMsg))
+      else console.log(logMsg)
+    })
+  }
+
+  // watch each file for changes
+  filesToWatch.forEach((filePath) => {
+    if (!existsSync(filePath)) return
+
+    watchFile(filePath, { persistent: true, interval: 500 }, (currStat, prevStat) => {
+      if (currStat.size === prevStat.size) return
+      readLog(filePath, prevStat.size, currStat.size)
+    })
+  })
+
+  console.log(`...watching logs...\n`)
+}
+
+module.exports = log

--- a/subcommands/publish/util.js
+++ b/subcommands/publish/util.js
@@ -24,7 +24,10 @@ const getPublishedVersion = (name, directory) => {
 const createZip = async ({ directory, version, excludePaths = [] }) => {
   const dir = `${directory}`
   const ZIP_TEMP_FOLDER = path.resolve(`./.tmp/upload`)
-  const EXCLUDE_IN_ZIP = ['node_modules', '.git', ...excludePaths].reduce((acc, ele) => `${acc} -x '${ele}/*'`, '')
+  const EXCLUDE_IN_ZIP = ['node_modules', '.git', '**/node_modules/*', '**/.git/*', ...excludePaths].reduce(
+    (acc, ele) => `${acc} -x '${ele}/*'`,
+    ''
+  )
 
   const zipFile = `${ZIP_TEMP_FOLDER}/${version}.zip`
   const zipDir = `${ZIP_TEMP_FOLDER}/${dir.substring(0, dir.lastIndexOf('/'))}`

--- a/subcommands/pullV2/index.js
+++ b/subcommands/pullV2/index.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const pull = require('./pullV2')
+
+module.exports = pull

--- a/subcommands/pullV2/plugins/HandleAddVariant.js
+++ b/subcommands/pullV2/plugins/HandleAddVariant.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable no-param-reassign */
+/* eslint-disable class-methods-use-this */
+
+const { readInput } = require('../../../utils/questionPrompts')
+const { forkRepo } = require('../utils/forkUtil')
+
+// eslint-disable-next-line no-unused-vars
+const PullCore = require('../pullCore')
+
+class HandleAddVariant {
+  /**
+   *
+   * @param {PullCore} pullCore
+   */
+  apply(pullCore) {
+    pullCore.hooks.beforePull.tapPromise(
+      'HandleAddVariant',
+      async (
+        /**
+         * @type {PullCore}
+         */
+        core
+      ) => {
+        const { blockDetails } = core
+        if (!core.createCustomVariant || blockDetails.is_purchased_variant) return
+
+        let newVariantType = ['fork', 'clone'].includes(core.variantType?.toLowerCase()) && core.variantType
+        if (!core.variantType) {
+          newVariantType = await readInput({
+            type: 'list',
+            name: 'isFork',
+            message: 'Choose variant type',
+            choices: ['Clone', 'Fork'],
+          })
+          core.variantType = newVariantType.toLowerCase()
+        }
+
+        if (newVariantType !== 'fork') return
+
+        // Fork Repo
+        const { sshUrl, blockFinalName } = await forkRepo(blockDetails)
+        core.blockDetails.forked_git_url = sshUrl
+        core.blockDetails.new_variant_block_name = blockFinalName
+        core.blockDetails.forked_block_name = blockFinalName
+      }
+    )
+  }
+}
+
+module.exports = HandleAddVariant

--- a/subcommands/pullV2/plugins/HandleAfterPull.js
+++ b/subcommands/pullV2/plugins/HandleAfterPull.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable no-param-reassign */
+/* eslint-disable class-methods-use-this */
+const chalk = require('chalk')
+const { existsSync, rm, readFileSync, writeFileSync } = require('fs')
+const path = require('path')
+const { blockTypeInverter } = require('../../../utils/blockTypeInverter')
+const convertGitSshUrlToHttps = require('../../../utils/convertGitUrl')
+const { getBlockMetaData } = require('../../../utils/registryUtils')
+
+// eslint-disable-next-line no-unused-vars
+const PullCore = require('../pullCore')
+
+class HandleAfterPull {
+  /**
+   *
+   * @param {PullCore} pullCore
+   */
+  apply(pullCore) {
+    pullCore.hooks.afterPull.tapPromise(
+      'HandleAfterPull',
+      async (
+        /**
+         * @type {PullCore}
+         */
+        core
+      ) => {
+        const { blockDetails } = core
+
+        const blockConfigPath = path.join(core.blockClonePath, 'block.config.json')
+
+        let blockConfig = {}
+
+        try {
+          blockConfig = JSON.parse(readFileSync(blockConfigPath, 'utf-8'))
+        } catch (err) {
+          if (err.code === 'ENOENT') {
+            console.log(chalk.dim('Pulled block has no config file, adding a new one'))
+            const language = blockDetails.block_type < 4 ? 'js' : 'nodejs'
+            blockConfig = {
+              type: blockTypeInverter(blockDetails.block_type),
+              language,
+              start: language === 'js' ? 'npx webpack-dev-server' : 'node index.js',
+              build: language === 'js' ? 'npx webpack' : '',
+              postPull: 'npm i',
+            }
+          }
+        }
+
+        if (core.createCustomVariant) {
+          if (blockDetails.purchased_parent_block_id) {
+            core.spinnies.add('pbRes', { text: 'Getting parent block meta data ' })
+            const parentBlockRes = await getBlockMetaData(blockDetails.purchased_parent_block_id)
+            core.spinnies.remove('pbRes')
+            if (parentBlockRes.data.err) throw new Error(parentBlockRes.data.msg)
+            const pbData = parentBlockRes.data.data
+
+            blockConfig.parent = {
+              id: blockDetails.purchased_parent_block_id,
+              name: pbData.block_name,
+              version: blockDetails.version_number,
+              version_id: blockDetails.version_id,
+            }
+          } else {
+            blockConfig.parent = {
+              id: blockDetails.block_id,
+              name: blockDetails.block_name,
+              version: blockDetails.version_number,
+              version_id: blockDetails.version_id,
+            }
+          }
+          blockConfig.source = {}
+        } else {
+          blockConfig.version = blockDetails.version_number
+          blockConfig.source = { https: convertGitSshUrlToHttps(blockDetails.git_url), ssh: blockDetails.git_url }
+        }
+
+        blockConfig.name = blockDetails.new_variant_block_name || blockDetails.block_name
+        writeFileSync(blockConfigPath, JSON.stringify(blockConfig, null, 2))
+
+        if (core.blockDetails.pull_by_config_folder_name) {
+          const tmpPath = path.join(core.tempAppblocksFolder, core.blockDetails.pull_by_config_folder_name)
+          if (blockDetails.pull_by_config && existsSync(tmpPath)) {
+            rm(tmpPath, { recursive: true, force: true }, () => {})
+          }
+        }
+
+        if (!core.appConfig.isOutOfContext) {
+          core.appConfig.addBlock({
+            directory: path.relative(core.cwd, core.blockClonePath),
+            meta: blockConfig,
+          })
+        }
+
+        // core.spinnies.add('packageInstaller', { text: 'Installing dependencies' })
+        // const { installer } = getNodePackageInstaller()
+
+        // const cmdRes = await runBash(installer)
+        // if (cmdRes.status === 'failed') {
+        //   core.spinnies.fail('packageInstaller', { text: cmdRes.msg })
+        // } else {
+        //   core.spinnies.succeed('packageInstaller', { text: 'Dependencies installed' })
+        // }
+        // core.spinnies.remove('packageInstaller')
+      }
+    )
+  }
+}
+
+module.exports = HandleAfterPull

--- a/subcommands/pullV2/plugins/HandleBeforePull.js
+++ b/subcommands/pullV2/plugins/HandleBeforePull.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable no-param-reassign */
+/* eslint-disable class-methods-use-this */
+const chalk = require('chalk')
+const { existsSync } = require('fs')
+const { confirmationPrompt, wantToCreateNewVersion, getBlockName } = require('../../../utils/questionPrompts')
+const { getAllAppblockVersions } = require('../../publish/util')
+// eslint-disable-next-line no-unused-vars
+const PullCore = require('../pullCore')
+
+class HandleBeforePull {
+  /**
+   *
+   * @param {PullCore} pullCore
+   */
+  apply(pullCore) {
+    pullCore.hooks.beforePull.tapPromise(
+      'HandleBeforePull',
+      async (
+        /**
+         * @type {PullCore}
+         */
+        core
+      ) => {
+        const { blockDetails } = core
+
+        core.spinnies.add('at', { text: `Checking appblock versions support` })
+        const abVers = await getAllAppblockVersions({ block_version_id: blockDetails.version_id })
+        core.spinnies.remove('at')
+        const bSab = abVers.data?.map(({ version }) => version) || []
+        const pbSab = core.appConfig.config?.supportedAppblockVersions
+        if (bSab?.length && pbSab?.length) {
+          const isSupported = bSab.some((version) => pbSab.includes(version))
+          if (!isSupported) {
+            const msg = `${core.appConfig.config.name} supported versions : ${pbSab}\n${blockDetails.block_name} supported versions : ${bSab}`
+            console.log(chalk.yellow(msg))
+            const goAhead = await confirmationPrompt({
+              name: 'goAhead',
+              message: `Found non-compatible appblock version in pulling block. Do you want to continue ?`,
+              default: false,
+            })
+
+            if (!goAhead) throw new Error('Cancelled pulling non-compatible block')
+          }
+        }
+
+        const { addVariant, variant } = core.cmdOpts
+
+        const { block_visibility: blockVisibility, is_purchased_variant: isPurchasedVariant } = blockDetails
+
+        core.createCustomVariant = false
+        if (isPurchasedVariant && blockVisibility !== 5) {
+          // FOR NOW: No variant allowed for purchased variant
+          core.createCustomVariant = false
+        } else if (addVariant === true || (isPurchasedVariant && blockVisibility === 5)) {
+          core.createCustomVariant = true
+        } else if (variant === false) core.createCustomVariant = false
+        else {
+          core.createCustomVariant = await wantToCreateNewVersion(blockDetails.block_name)
+        }
+
+        if (!core.blockDetails.version_id && core.createCustomVariant) {
+          throw new Error(`Variant can't be created under block without version`)
+        }
+
+        // check if block exist
+        let blockExistMsg = ''
+        if (core.appConfig.has(core.blockDetails.block_name)) {
+          blockExistMsg = `Block already exists in local`
+        } else if (existsSync(core.blockClonePath)) {
+          blockExistMsg = `Folder with block name already exists`
+        }
+
+        if (blockExistMsg) {
+          if (core.createCustomVariant) {
+            const goAhead = await confirmationPrompt({
+              message: `${blockExistMsg}, Do you want to continue with new name ?`,
+              name: 'goAhead',
+            })
+            if (!goAhead) throw new Error(blockExistMsg)
+
+            core.blockDetails.new_variant_block_name = await getBlockName()
+          } else {
+            throw new Error(blockExistMsg)
+          }
+        }
+      }
+    )
+  }
+}
+
+module.exports = HandleBeforePull

--- a/subcommands/pullV2/plugins/HandleBlockPull.js
+++ b/subcommands/pullV2/plugins/HandleBlockPull.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable no-param-reassign */
+/* eslint-disable class-methods-use-this */
+
+const path = require('path')
+const { existsSync } = require('fs')
+const { GitManager } = require('../../../utils/gitManagerV2')
+const { pullSourceCodeFromAppblock } = require('../utils/sourceCodeUtil')
+// eslint-disable-next-line no-unused-vars
+const PullCore = require('../pullCore')
+
+class HandleBlockPull {
+  /**
+   *
+   * @param {PullCore} pullCore
+   */
+  apply(pullCore) {
+    pullCore.hooks.beforePull.tapPromise(
+      'HandleBlockPull',
+      async (
+        /**
+         * @type {PullCore}
+         */
+        core
+      ) => {
+        if (core.blockDetails.blockType === 'package') return
+
+        const cloneGitUrl = core.blockDetails.forked_git_url || core.blockDetails.git_url
+        const cloneBlockName = core.blockDetails.new_variant_block_name || core.blockDetails.block_name
+        const clonePath = path.join(core.cwd, cloneBlockName)
+
+        // check if clone folder already exist
+        if (existsSync(clonePath)) {
+          throw new Error(`Folder already exist`)
+        }
+
+        if (core.blockDetails.is_purchased_variant && core.blockDetails.block_visibility === 5) {
+          // Block source code will be downloaded form s3
+          core.spinnies.add('pab', { text: 'pulling block source code' })
+          await pullSourceCodeFromAppblock({
+            blockFolderPath: core.blockClonePath,
+            blockDetails: core.blockDetails,
+            appId: core.appData.app_id,
+          })
+          core.spinnies.remove('pab')
+          return
+        }
+
+        // Clone repo from git
+        core.spinnies.add('fork', { text: `Cloning repo ${core.blockDetails.block_name}` })
+
+        const git = new GitManager(core.cwd, cloneGitUrl)
+        await git.clone(clonePath)
+
+        if (core.blockDetails.version_number) {
+          await git.fetch('--all --tags')
+          await git.checkoutTag(core.blockDetails.version_number)
+        }
+
+        core.spinnies.succeed('fork', { text: `Block ${core.blockDetails.block_name} cloned successfully` })
+        core.blockDetails.final_block_path = clonePath
+        core.blockClonePath = clonePath
+      }
+    )
+  }
+}
+
+module.exports = HandleBlockPull

--- a/subcommands/pullV2/plugins/HandleCheckPurchasedPull.js
+++ b/subcommands/pullV2/plugins/HandleCheckPurchasedPull.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-param-reassign */
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable class-methods-use-this */
+
+// eslint-disable-next-line no-unused-vars
+const PullCore = require('../pullCore')
+const deployConfigManager = require('../../deploy/manager')
+const { checkBlockAssignedToApp, assignBlockToApp } = require('../../../utils/api')
+const { post } = require('../../../utils/axios')
+const { configstore } = require('../../../configstore')
+const { confirmationPrompt } = require('../../../utils/questionPrompts')
+
+class HandleCheckPurchasedPull {
+  /**
+   *
+   * @param {PullCore} pullCore
+   */
+  apply(pullCore) {
+    pullCore.hooks.beforePull.tapPromise(
+      'HandleCheckPurchasedPull',
+      async (
+        /**
+         * @type {PullCore}
+         */
+        core
+      ) => {
+        const { blockDetails } = core
+        if (!blockDetails.is_purchased_variant) return
+
+        // Pulling purchased block code
+
+        await deployConfigManager.init()
+        const appData = deployConfigManager.deployAppConfig
+
+        if (!appData?.app_id) {
+          throw new Error(`App does not exist to pull\n`)
+        }
+        
+        core.appData = appData
+
+        core.spinnies.add('bp', { text: 'Checking if block is assigned with app' })
+        const { error: checkErr, data: checkD } = await post(checkBlockAssignedToApp, {
+          block_id: blockDetails.block_id,
+          app_id: appData.app_id,
+          space_id: configstore.get('currentSpaceId'),
+        })
+        core.spinnies.remove('bp')
+        if (checkErr) throw checkErr
+
+        const checkData = checkD.data || {}
+
+        if (!checkData.exist) {
+          if (!checkData.can_assign) {
+            throw new Error(`Block is not assigned with ${appData.app_name} \n`)
+          }
+
+          const assignAndContinue = await confirmationPrompt({
+            name: 'assignAndContinue',
+            message: `Block is not assigned. Do you wish to assign ${blockDetails.block_name} block with ${appData.app_name}`,
+            default: false,
+          })
+
+          if (!assignAndContinue) throw new Error('Paid block should be assigned to an app').message
+
+          core.spinnies.add('bp', { text: 'assigning block with app' })
+          const { error: assignErr } = await post(assignBlockToApp, {
+            block_id: blockDetails.block_id,
+            app_id: appData.app_id,
+            space_id: configstore.get('currentSpaceId'),
+          })
+          core.spinnies.remove('bp')
+          if (assignErr) throw assignErr
+        }
+      }
+    )
+  }
+}
+
+module.exports = HandleCheckPurchasedPull

--- a/subcommands/pullV2/plugins/HandleGetPullBlockDetails.js
+++ b/subcommands/pullV2/plugins/HandleGetPullBlockDetails.js
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable class-methods-use-this */
+/* eslint-disable no-param-reassign */
+
+const path = require('path')
+const { existsSync, readFileSync, cp, rm } = require('fs')
+const { getBlockPermissionsApi } = require('../../../utils/api')
+const { post } = require('../../../utils/axios')
+const { confirmationPrompt } = require('../../../utils/questionPrompts')
+const { getBlockDetails, getBlockMetaData, getAllBlockVersions } = require('../../../utils/registryUtils')
+// eslint-disable-next-line no-unused-vars
+const PullCore = require('../pullCore')
+
+class HandleGetPullBlockDetails {
+  /**
+   *
+   * @param {PullCore} pullCore
+   */
+  apply(pullCore) {
+    pullCore.hooks.beforePull.tapPromise(
+      'HandleGetPullBlockDetails',
+      async (
+        /**
+         * @type {PullCore}
+         */
+        core
+      ) => {
+        const hasBlockId = core.cmdOpts.id
+        let pullId = hasBlockId && core.cmdArgs.pullByBlock
+
+        let metaData = {}
+
+        try {
+          // eslint-disable-next-line prefer-const
+          let [componentName, componentVersion] = core.cmdArgs.pullByBlock?.startsWith('@')
+            ? core.cmdArgs.pullByBlock?.replace('@', '')?.split('@') || []
+            : core.cmdArgs.pullByBlock?.split('@') || []
+
+          core.pullBlockName = componentName
+          core.pullBlockVersion = componentVersion
+
+          if (!core.pullBlockName && !hasBlockId) {
+            if (!existsSync(core.appConfig.blockConfigName)) {
+              throw new Error('Block name or Block config not found')
+            }
+            const config = JSON.parse(readFileSync(core.appConfig.blockConfigName))
+            if (!config.blockId) throw new Error('Block ID not found in block config')
+
+            core.pullBlockName = config.name
+
+            const goAhead = await confirmationPrompt({
+              message: `You are trying to pull ${core.pullBlockName} by config ?`,
+              default: false,
+              name: 'goAhead',
+            })
+
+            if (!goAhead) {
+              core.feedback({ type: 'error', message: `Process cancelled` })
+              throw new Error('Process cancelled')
+            }
+
+            pullId = config.blockId
+            metaData.pull_by_config = true
+            metaData.block_config = config
+            const pullByConfigFolderName = path.basename(path.resolve())
+            metaData.pull_by_config_folder_name = pullByConfigFolderName
+            core.blockDetails = metaData
+
+            process.chdir('../')
+            cp(
+              pullByConfigFolderName,
+              path.join(core.tempAppblocksFolder, pullByConfigFolderName),
+              { recursive: true },
+              (err) => {
+                if (err) throw err
+                rm(pullByConfigFolderName, { recursive: true, force: true }, () => {})
+              }
+            )
+            core.pullBlockVersion = config.version
+            core.cwd = path.resolve('.')
+            await core.appConfig.init(core.cwd, null, 'pull', { reConfig: true })
+          }
+
+          core.logger.info(`pull ${core.pullBlockName} in cwd:${core.cwd}`)
+          /**
+           * @type {import('../../utils/jsDoc/types').blockDetailsdataFromRegistry}
+           */
+
+          /**
+           * @type {{status:number,data:{err:string,data:import('../../utils/jsDoc/types').blockDetailsdataFromRegistry,msg:string}}}
+           */
+
+          core.spinnies.add('blockExistsCheck', { text: `Searching for ${core.pullBlockName}` })
+
+          // check if pull by id
+          if (!hasBlockId) {
+            const {
+              status,
+              data: { err, data: blockDetails },
+            } = await getBlockDetails(core.pullBlockName)
+
+            if (status === 204) {
+              throw new Error(`${core.pullBlockName} doesn't exists in block repository`)
+            }
+            if (err) throw new Error(err)
+
+            pullId = blockDetails.id
+            metaData = { ...metaData, ...blockDetails }
+            core.pullBlockName = metaData.block_name
+            core.blockDetails = metaData
+          }
+
+          const c = await getBlockMetaData(pullId)
+
+          if (c.data.err) throw new Error(c.data.msg)
+
+          if (c.status === 204) {
+            throw new Error(`${core.pullBlockName} doesn't exists in block repository`)
+          }
+
+          core.spinnies.succeed('blockExistsCheck', { text: `${core.pullBlockName} is available` })
+          core.spinnies.remove('blockExistsCheck')
+
+          const blockMeta = c.data?.data
+          metaData = { ...metaData, ...blockMeta, id: blockMeta.block_id }
+          metaData.parent_id = metaData.purchased_parent_block_id || metaData.block_id
+
+          core.pullBlockVersion = null
+          core.blockDetails = metaData
+
+          core.spinnies.add('pab', { text: 'checking block permission ' })
+          const { data: pData, error: pErr } = await post(getBlockPermissionsApi, {
+            block_id: metaData.block_id,
+          })
+          core.spinnies.remove('pab')
+          if (pErr) throw pErr
+
+          delete pData.data?.id
+
+          metaData = { ...metaData, ...pData.data }
+
+          const {
+            has_access: hasBlockAccess,
+            has_pull_access: hasPullBlockAccess,
+            block_visibility: blockVisibility,
+            is_purchased_variant: isPurchasedVariant,
+          } = metaData
+
+          if (!hasBlockAccess && !hasPullBlockAccess) {
+            if (blockVisibility === 4) {
+              throw new Error(`Please use get command to get free ${componentName}`)
+            }
+            throw new Error(`Access denied for block ${componentName}`)
+          }
+
+          metaData.parent_id = metaData.purchased_parent_block_id || metaData.block_id
+
+          let statusFilter = hasBlockAccess ? undefined : [4]
+          let versionOf = metaData.block_id
+          if (isPurchasedVariant && blockVisibility === 5) {
+            statusFilter = [4] // approved versions
+            versionOf = metaData.purchased_parent_block_id
+          }
+          const bv = await getAllBlockVersions(versionOf, {
+            status: statusFilter,
+          })
+
+          if (bv.data.err) {
+            throw new Error(bv.data.msg)
+          }
+
+          if (bv.status === 204 && !hasPullBlockAccess && !hasBlockAccess) {
+            throw new Error('No version found for the block to pull')
+          }
+
+          const blockVersions = bv.data.data
+          const latestVersion = blockVersions?.[0]
+          if (!latestVersion) {
+            const continueWithLatest = await confirmationPrompt({
+              name: 'continueWithLatest',
+              message: `Block version not specified. Do you want to pull the latest code?`,
+            })
+
+            if (!continueWithLatest) throw new Error('Cancelled Pulling block with latest code')
+            return
+          }
+
+          if (componentVersion && componentVersion !== 'latest') {
+            metaData.version_id = blockVersions.find((v) => v.version_number === componentVersion)?.id
+            metaData.version_number = componentVersion
+          } else {
+            if (componentVersion !== 'latest') {
+              const continueWithLatest = await confirmationPrompt({
+                name: 'continueWithLatest',
+                message: `Block version not specified. Do you want to pull the latest versions ${latestVersion.version_number}?`,
+              })
+              if (!continueWithLatest) throw new Error('No version specified')
+            }
+
+            // get the latest version of parent
+            metaData.version_id = latestVersion?.id
+            metaData.version_number = latestVersion?.version_number
+          }
+
+          if (!metaData.version_id) {
+            throw new Error(`${componentVersion} version not found `)
+          }
+
+          core.blockDetails = metaData
+        } catch (err) {
+          if (err.response?.status === 401 || err.response?.status === 403) {
+            throw new Error(`Access denied for block ${core.pullBlockName}`)
+          }
+          throw err
+        }
+      }
+    )
+  }
+}
+module.exports = HandleGetPullBlockDetails

--- a/subcommands/pullV2/plugins/HandleNoVariant.js
+++ b/subcommands/pullV2/plugins/HandleNoVariant.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable class-methods-use-this */
+
+const { appConfig } = require('../../../utils/appconfigStore')
+const { confirmationPrompt } = require('../../../utils/questionPrompts')
+
+// eslint-disable-next-line no-unused-vars
+const PullCore = require('../pullCore')
+
+class HandleNoVariant {
+  /**
+   *
+   * @param {PullCore} pullCore
+   */
+  apply(pullCore) {
+    pullCore.hooks.beforePull.tapPromise(
+      'HandleNoVariant',
+      async (
+        /**
+         * @type {PullCore}
+         */
+        core
+      ) => {
+        if (core.createCustomVariant) return
+
+        const { blockDetails } = core
+
+        if (blockDetails.pull_by_config && core.pullByConfigFolderName !== blockDetails.block_name) {
+          const goAhead = await confirmationPrompt({
+            name: 'goAhead',
+            message: `Block name and folder name should be same. Do you want to rename ${core.pullByConfigFolderName} to ${blockDetails.block_name} ?`,
+          })
+
+          if (!goAhead) throw new Error('Cannot proceed with different name')
+        }
+
+        const existingBlock = appConfig.getBlock(core.pullBlockName)
+        if (existingBlock) {
+          throw new Error(`${core.pullBlockName} already exists at ${existingBlock.directory}`)
+        }
+      }
+    )
+  }
+}
+
+module.exports = HandleNoVariant

--- a/subcommands/pullV2/plugins/HandleOutOfContext.js
+++ b/subcommands/pullV2/plugins/HandleOutOfContext.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable class-methods-use-this */
+/* eslint-disable no-param-reassign */
+
+const { blockTypeInverter } = require('../../../utils/blockTypeInverter')
+// eslint-disable-next-line no-unused-vars
+const PullCore = require('../pullCore')
+
+class HandleOutOfContext {
+  /**
+   *
+   * @param {PullCore} pullCore
+   */
+  apply(pullCore) {
+    pullCore.hooks.beforePull.tapPromise(
+      'HandleOutOfContext',
+      async (
+        /**
+         * @type {PullCore}
+         */
+        core
+      ) => {
+        const blockType = blockTypeInverter(core.blockDetails.block_type)
+        if (core.appConfig.isOutOfContext && blockType !== 'package') {
+          throw new Error(
+            `You are trying to pull a ${blockType} block outside package context. Please create a package or pull into an existing package context`
+          )
+        }
+      }
+    )
+  }
+}
+module.exports = HandleOutOfContext

--- a/subcommands/pullV2/plugins/HandlePackagePull.js
+++ b/subcommands/pullV2/plugins/HandlePackagePull.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable class-methods-use-this */
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { spinnies } = require('../../../loader')
+const { appBlockGetAppConfig } = require('../../../utils/api')
+const { post } = require('../../../utils/axios')
+const { cloneBlock } = require('../utils')
+
+// eslint-disable-next-line no-unused-vars
+const PullCore = require('../pullCore')
+
+class HandlePackagePull {
+  /**
+   *
+   * @param {PullCore} pullCore
+   */
+  apply(pullCore) {
+    pullCore.hooks.beforePull.tapPromise(
+      'HandlePackagePull',
+      async (
+        /**
+         * @type {PullCore}
+         */
+        core
+      ) => {
+        const { blockDetails } = core
+        if (blockDetails.blockType !== 'package') return
+
+        // Handle package block
+
+        spinnies.add('pab', { text: 'Getting package config data ' })
+        const { data: appConfigData, error } = await post(appBlockGetAppConfig, {
+          block_id: blockDetails.block_id,
+          block_version_id: blockDetails.version_id,
+        })
+        spinnies.remove('pab')
+        if (error) throw error
+        const packageConfigData = appConfigData?.data?.app_config
+        if (!packageConfigData) throw new Error('Error getting app config data')
+
+        const { dependencies, repoType } = packageConfigData
+        const { blockTypes } = core.cmdOpts
+
+        if (core.blockDetails.is_purchased_variant) {
+          // Block source code will be downloaded form s3
+          throw new Error('Purchased package pull is still in progress!!!')
+        }
+
+        const { cloneFolder: packageFolderPath } = await cloneBlock({
+          block_name: blockDetails.block_name,
+          git_url: blockDetails.git_url,
+          rootPath: core.cwd,
+        })
+
+        core.blockClonePath = packageFolderPath
+
+        if (dependencies && repoType !== 'mono') {
+          await Promise.all(
+            Object.values(dependencies).map(async (dep) => {
+              const { type, name, source } = dep.meta
+              if (blockTypes?.length && !blockTypes.includes(type)) return false
+              await cloneBlock({ block_name: name, git_url: source.ssh, rootPath: packageFolderPath })
+              return true
+            })
+          )
+        }
+
+        spinnies.add('pbp', { text: 'Pulled package block successfully ' })
+        spinnies.succeed('pbp', { text: 'Pulled package block successfully ' })
+      }
+    )
+  }
+}
+
+module.exports = HandlePackagePull

--- a/subcommands/pullV2/pullCore.js
+++ b/subcommands/pullV2/pullCore.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const path = require('path')
+const { tmpdir } = require('os')
+const { existsSync, cp, rm } = require('fs')
+const { AsyncSeriesHook } = require('tapable')
+
+const { appConfig } = require('../../utils/appconfigStore')
+// eslint-disable-next-line no-unused-vars
+const { feedback } = require('../../utils/cli-feedback')
+// eslint-disable-next-line no-unused-vars
+const { Logger } = require('../../utils/loggerV2')
+// eslint-disable-next-line no-unused-vars
+const { spinnies } = require('../../loader')
+
+class PullCore {
+  constructor(pullByBlock, cmdOptions, options) {
+    this.cmdArgs = { pullByBlock }
+    this.cmdOpts = { ...cmdOptions }
+
+    /**
+     * @type {logger}
+     */
+    this.logger = options.logger
+    /**
+     * @type {feedback}
+     */
+    this.feedback = options.feedback
+    /**
+     * @type {spinnies}
+     */
+    this.spinnies = options.spinnies
+
+    this.cwd = process.cwd()
+    this.blockToPull = null
+    this.blockDetails = {}
+    this.tempPath = tmpdir()
+    this.tempAppblocksFolder = `${this.tempPath}/_appblocks_/`
+
+    this.hooks = {
+      beforePull: new AsyncSeriesHook(['core']),
+      afterPull: new AsyncSeriesHook(['core']),
+    }
+  }
+
+  async initializeAppConfig() {
+    if (!this.cmdArgs.pullByBlock) {
+      this.cwd = path.dirname(this.cwd)
+    }
+
+    await appConfig.initV2(this.cwd, null, 'pull')
+    this.appConfig = appConfig || {}
+  }
+
+  async pullBlock() {
+    try {
+      await this.hooks.beforePull?.promise(this)
+
+      // core things
+
+      await this.hooks.afterPull?.promise(this)
+    } catch (error) {
+      if (this.blockDetails.pull_by_config_folder_name) {
+        const tmpPath = path.join(this.tempAppblocksFolder, this.blockDetails.pull_by_config_folder_name)
+        if (this.blockDetails.pull_by_config && existsSync(tmpPath)) {
+          cp(tmpPath, this.blockDetails.pull_by_config_folder_name, { recursive: true }, (err) => {
+            if (err) feedback({ type: 'info', err })
+            rm(tmpPath, { recursive: true, force: true }, () => {})
+          })
+        }
+      }
+
+      throw error
+    }
+  }
+}
+
+module.exports = PullCore

--- a/subcommands/pullV2/pullV2.js
+++ b/subcommands/pullV2/pullV2.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { spinnies } = require('../../loader')
+const { feedback } = require('../../utils/cli-feedback')
+const { Logger } = require('../../utils/loggerV2')
+const HandleGetPullBlockDetails = require('./plugins/HandleGetPullBlockDetails')
+const HandlePackagePull = require('./plugins/HandlePackagePull')
+const HandleBlockPull = require('./plugins/HandleBlockPull')
+const PullCore = require('./pullCore')
+const HandleOutOfContext = require('./plugins/HandleOutOfContext')
+const HandleAddVariant = require('./plugins/HandleAddVariant')
+const HandleNoVariant = require('./plugins/HandleNoVariant')
+const HandleBeforePull = require('./plugins/HandleBeforePull')
+const HandleCheckPurchasedPull = require('./plugins/HandleCheckPurchasedPull')
+const HandleAfterPull = require('./plugins/HandleAfterPull')
+
+async function pull(pullByBlock, cmdOptions) {
+  const { logger } = new Logger('pull')
+  const Pull = new PullCore(pullByBlock, cmdOptions, { logger, spinnies, feedback })
+  try {
+    new HandleGetPullBlockDetails().apply(Pull)
+    new HandleOutOfContext().apply(Pull)
+    new HandleBeforePull().apply(Pull)
+    new HandleAddVariant().apply(Pull)
+    new HandleNoVariant().apply(Pull)
+    new HandleCheckPurchasedPull().apply(Pull)
+    new HandleBlockPull().apply(Pull)
+    new HandlePackagePull().apply(Pull)
+
+    new HandleAfterPull().apply(Pull)
+
+    await Pull.initializeAppConfig()
+    await Pull.pullBlock()
+  } catch (error) {
+    console.log(error)
+    logger.error(error)
+    spinnies.add('err', { text: error.message })
+    spinnies.fail('err', { text: error.message })
+    spinnies.stopAll()
+  }
+}
+
+module.exports = pull

--- a/subcommands/pullV2/utils/forkUtil.js
+++ b/subcommands/pullV2/utils/forkUtil.js
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable prefer-promise-reject-errors */
+/* eslint-disable no-async-promise-executor */
+
+const { default: axios } = require('axios')
+const inquirer = require('inquirer')
+const { configstore } = require('../../../configstore')
+const { githubOrigin, githubRestOrigin, githubGraphQl } = require('../../../utils/api')
+const checkBlockNameAvailability = require('../../../utils/checkBlockNameAvailability')
+const { getGitHeader } = require('../../../utils/getHeaders')
+const { updateRepository } = require('../../../utils/Mutations')
+const { getOrgId } = require('../../../utils/questionPrompts')
+const { spinnies } = require('../../../loader')
+
+/**
+ *
+ * @param {String} forkGitUrl
+ * @returns {String}
+ */
+const getUserRepoName = (forkGitUrl) =>
+  forkGitUrl.includes(githubOrigin)
+    ? forkGitUrl.replace(`${githubOrigin}/`, '')
+    : forkGitUrl.replace('git@github.com:', '').replace('.git', '')
+
+/**
+ *
+ * @param {String} userRepo
+ * @param {String} newBlockName
+ * @returns {Object | String}
+ */
+const forkRepoPost = async (userRepo, newBlockName, organization, branchType) => {
+  try {
+    const postData = {
+      name: newBlockName,
+      default_branch_only: branchType,
+    }
+
+    if (organization != null) {
+      postData.organization = organization
+    }
+
+    const res = await axios.post(`${githubRestOrigin}/repos/${userRepo}/forks`, postData, { headers: getGitHeader() })
+    return { data: res.data, blockFinalName: newBlockName }
+  } catch (err) {
+    if (err.response.status === 404) {
+      throw new Error('Repo not found Or Trying to fork private repo')
+    } else if (err.response.type === 'UNPROCESSABLE') {
+      const newShortName = await checkBlockNameAvailability('', true)
+      return forkRepoPost(userRepo, newShortName, organization)
+    } else throw new Error(err.response.data.message)
+  }
+}
+
+/**
+ * @returns {Object}
+ */
+const readRepoInputs = async () => {
+  const question = [
+    {
+      type: 'list',
+      message: 'where to fork repo',
+      name: 'gitType',
+      choices: ['my git', 'org git'],
+    },
+    {
+      type: 'confirm',
+      message: 'Fork default branch only',
+      name: 'defaultBranchOnly',
+      default: true,
+    },
+    // {
+    //   type: 'input',
+    //   name: 'description',
+    //   message: 'Description of repo',
+    // },
+    // {
+    //   type: 'list',
+    //   name: 'visibility',
+    //   message: 'visibility of repo',
+    //   choices: ['PRIVATE', 'PUBLIC'],
+    // },
+  ]
+
+  const promtRes = await inquirer.prompt(question)
+  return promtRes
+}
+
+/**
+ *
+ * @returns {Object}
+ */
+const getRepoInputs = async () => {
+  const repoInputs = await readRepoInputs()
+  if (repoInputs.gitType === 'my git') {
+    const userName = configstore.get('githubUserName')
+    const userId = configstore.get('githubUserId')
+    return {
+      ...repoInputs,
+      userName,
+      userId,
+    }
+  }
+
+  const [orgName, orgId] = await getOrgId()
+  return { ...repoInputs, orgId, orgName }
+}
+
+/**
+ *
+ * @param {Object} ans
+ * @returns
+ */
+const updateRepo = async (ans) => {
+  const { data: innerData } = await axios.post(
+    githubGraphQl,
+    {
+      query: updateRepository.Q,
+      variables: {
+        description: ans.description,
+        visibility: ans.visibility,
+        team: ans.selectTeam || null,
+      },
+    },
+    { headers: getGitHeader() }
+  )
+  if (innerData.errors) {
+    throw new Error(`Something went wrong with query, \n${JSON.stringify(innerData)}`)
+  }
+
+  return innerData
+}
+
+/**
+ *
+ * @param {Object} metaData
+ * @param {String} newBlockName
+ * @param {String} clonePath
+ * @returns {Object | String}
+ */
+const forkRepo = (metaData) =>
+  new Promise(async (resolve, reject) => {
+    try {
+      const { GitUrl: forkGitUrl } = metaData
+
+      const userInputs = await getRepoInputs()
+      const userRepo = getUserRepoName(forkGitUrl)
+      spinnies.add('fork', { text: `Forking the repository` })
+
+      const { orgName, userName, defaultBranchOnly } = userInputs
+
+      const {
+        data: { description, visibility, svn_url: url, ssh_url: sshUrl, name },
+        blockFinalName,
+      } = await forkRepoPost(userRepo, metaData.block_name, orgName, defaultBranchOnly)
+
+      if (name !== blockFinalName) {
+        throw new Error(`Fork already exists as ${orgName || userName}/${name}`)
+      }
+
+      spinnies.succeed('fork', { text: `Successfully forked` })
+      resolve({ description, visibility, url, sshUrl, name, blockFinalName })
+    } catch (err) {
+      spinnies.add('fork')
+      spinnies.fail('fork', { text: `Failed to fork` })
+      reject(err)
+    }
+  })
+
+module.exports = { forkRepo, updateRepo }

--- a/subcommands/pullV2/utils/index.js
+++ b/subcommands/pullV2/utils/index.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { path } = require('@babel/traverse/lib/cache')
+const { spinnies } = require('../../../loader')
+const { GitManager } = require('../../../utils/gitManagerV2')
+
+const cloneBlock = async ({ block_name, git_url, rootPath }) => {
+  spinnies.add(block_name, { text: `Pulling ${block_name}` })
+  const Git = new GitManager(rootPath, git_url)
+  const cloneFolder = path.join(rootPath, block_name)
+  await Git.clone(cloneFolder)
+  spinnies.succeed(block_name, { text: `Pulled ${block_name} ` })
+
+  return { cloneFolder }
+}
+
+module.exports = { cloneBlock }

--- a/subcommands/pullV2/utils/sourceCodeUtil.js
+++ b/subcommands/pullV2/utils/sourceCodeUtil.js
@@ -1,0 +1,80 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable arrow-body-style */
+const { execSync } = require('child_process')
+const decompress = require('decompress')
+const { createWriteStream } = require('fs')
+const { tmpdir } = require('os')
+const path = require('path')
+const configstore = require('../../../configstore')
+const { getSourceCodeSignedUrl } = require('../../../utils/api')
+const { post, axiosGet } = require('../../../utils/axios')
+
+const downloadSourceCode = async (url, blockFolderPath, blockName) => {
+  // eslint-disable-next-line no-async-promise-executor
+  return new Promise(async (resolve, reject) => {
+    const tempPath = path.join(tmpdir(), `${blockName}.zip`)
+    const writer = createWriteStream(tempPath)
+
+    const { data, error } = await axiosGet(url, {
+      responseType: 'stream',
+      noHeaders: true,
+    })
+
+    if (error) {
+      reject(error)
+      return
+    }
+
+    if (!data) {
+      reject(new Error('No source code found'))
+      return
+    }
+
+    data.pipe(writer)
+    writer.on('error', (err) => reject(err))
+    writer.on('finish', async () => {
+      writer.close()
+      await decompress(tempPath, blockFolderPath)
+      execSync(`rm -r ${tempPath}`)
+      return resolve(true)
+    })
+  })
+}
+
+const getSignedSourceCodeUrl = async ({ blockDetails, appId, spaceId, blockId, variantBlockId }) => {
+  const postData = {
+    block_id: blockId,
+    block_version_id: blockDetails.version_id,
+  }
+
+  if (appId) postData.app_id = appId
+  if (spaceId) postData.space_id = spaceId
+  if (variantBlockId) postData.variant_block_id = variantBlockId
+
+  const { data, error } = await post(getSourceCodeSignedUrl, postData)
+
+  if (error) throw error
+
+  const resData = data.data
+
+  if (resData?.member_blocks_url) {
+    return { download_url: resData.download_url, member_blocks_url: resData.member_blocks_url }
+  }
+
+  return resData?.download_url
+}
+
+const pullSourceCodeFromAppblock = async (options) => {
+  const { blockFolderPath, blockDetails } = options || {}
+
+  options.blockId = blockDetails.parent_id
+  options.variantBlockId = blockDetails.block_id
+  options.spaceId = configstore.get('currentSpaceId')
+
+  const signedSourceCodeUrl = await getSignedSourceCodeUrl(options)
+  if (!signedSourceCodeUrl) throw new Error('Error getting source code from appblocks')
+
+  await downloadSourceCode(signedSourceCodeUrl, blockFolderPath, blockDetails.block_name)
+}
+
+module.exports = { pullSourceCodeFromAppblock, downloadSourceCode, getSignedSourceCodeUrl }

--- a/subcommands/upload/onPrem/awsS3/singleBuild.js
+++ b/subcommands/upload/onPrem/awsS3/singleBuild.js
@@ -65,12 +65,12 @@ const singleBuildDeployment = async ({ deployConfigManager, config, opdBackupFol
     uploadKeys.elements = uploadedBlocks
     spinnies.succeed(`ele`, { text: `Uploaded elements successfully` })
 
-    spinnies.add(`cont`, { text: `Building container` })
+    spinnies.add(`cont`, { text: `Building ui container` })
 
     // Upload Container
     const { blockBuildFolder, error } = await buildBlock(containerBlock, {}, env)
 
-    if (!blockBuildFolder) throw new Error(`Error building container ${error}`)
+    if (!blockBuildFolder) throw new Error(`Error building ui container ${error}`)
 
     spinnies.update('cont', { text: `Uploading container` })
     const uploadedContainer = await s3Handler.uploadDir({

--- a/subcommands/upload/onPrem/index.js
+++ b/subcommands/upload/onPrem/index.js
@@ -17,24 +17,30 @@ const onPremUpload = async (options) => {
   await awsHandler.syncAWSConfig()
 
   const OPDConfig = await deployConfigManager.syncOnPremDeploymentConfig(options)
-  const OPDNames = Object.keys(OPDConfig)
+  let config
 
-  const choices = OPDNames.map((name) => ({ name, value: OPDConfig[name] }))
+  if (options.configName) {
+    config = OPDConfig?.[options.configName]
+    if (!config) throw new Error(`No on-premise configuration found with name ${options.configName}`)
+  } else {
+    const OPDNames = Object.keys(OPDConfig)
+    const choices = OPDNames.map((name) => ({ name, value: OPDConfig[name] }))
 
-  choices.unshift({
-    name: 'Create new deployment configuration',
-    value: null,
-  })
+    choices.unshift({
+      name: 'Create new deployment configuration',
+      value: null,
+    })
 
-  let config = await readInput({
-    type: 'list',
-    name: 'config',
-    message: 'Select upload to existing deploy config',
-    choices,
-  })
+    config = await readInput({
+      type: 'list',
+      name: 'config',
+      message: 'Select upload to existing deploy config',
+      choices,
+    })
 
-  if (!config) {
-    config = await deployConfigManager.createOnPremDeploymentConfig({ ...options, existingConfigNames: OPDNames })
+    if (!config) {
+      config = await deployConfigManager.createOnPremDeploymentConfig({ ...options, existingConfigNames: OPDNames })
+    }
   }
 
   config.deployed = await deployConfigManager.readOnPremDeployedConfig[config.name]


### PR DESCRIPTION
# Make upload and deploy linear command

This pr will help the developers to run deploy and upload command without any prompt for On-premise deployment.

## Note to users

User can pass a flag `-cn` or `--config-name` which basically expects the name of the configuration after the flag.
Eg: bb upload -cn my_func_config_name  OR bb deploy -cn my_func_config_name