### PR TITLE
feat bb push nested

### DIFF
--- a/bin/bb-connect-remote.cjs
+++ b/bin/bb-connect-remote.cjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { Command } = require('commander')
+const connectRemote = require('../subcommands/connectRemote')
+const { isGitInstalled } = require('../utils/gitCheckUtils')
+const checkAndSetGitConnectionPreference = require('../utils/checkAndSetGitConnectionStrategy')
+
+const program = new Command().hook('preAction', async () => {
+  if (!isGitInstalled()) {
+    console.log('Git not installed')
+    process.exitCode = 1
+  }
+  await checkAndSetGitConnectionPreference()
+})
+
+program
+  .option('-f, --force', 'Force with new repository')
+  .option('-ssh, --ssh-url <ssh-url>', 'Git ssh url of the repository')
+  .action(connectRemote)
+
+program.parse(process.argv)

--- a/bin/bb.cjs
+++ b/bin/bb.cjs
@@ -114,6 +114,8 @@ cmd('use', 'to select space')
 
 cmd('set-appblock-version', 'To add supported version of appblock to block')
 
+cmd('connect-remote', 'To add remote for package block')
+
 /**
  * PRIVATE FEATURES
  */

--- a/subcommands/connectRemote/index.js
+++ b/subcommands/connectRemote/index.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const path = require('path')
+const { existsSync } = require('fs')
+const { writeFile } = require('fs/promises')
+const { createRepo } = require('../../utils/createRepoV2')
+const { confirmationPrompt } = require('../../utils/questionPrompts')
+const convertGitSshUrlToHttps = require('../../utils/convertGitUrl')
+const { spinnies } = require('../../loader')
+const { tryGitInit, isInGitRepository } = require('../../utils/gitCheckUtils')
+const { generateGitIgnore } = require('../../templates/createTemplates/function-templates')
+const { initializeConfig, updateAllMemberConfig } = require('./util')
+
+const connectRemote = async (cmdOptions) => {
+  try {
+    spinnies.add('cr', { text: 'Initializing Config' })
+    const manager = await initializeConfig()
+    const { err } = await manager.findMyParentPackage()
+    spinnies.remove('cr')
+
+    if (!err && manager.config.repoType === 'mono') {
+      throw new Error('Please run this command from root package context')
+    }
+
+    if (manager.config.source.https && !cmdOptions.force) {
+      const goAhead = await confirmationPrompt({
+        message: `Source already exist. Do you want to replace with new source ?`,
+        name: 'goAhead',
+      })
+
+      if (!goAhead) throw new Error('Source already exist')
+    }
+
+    // check if already git initialized else init
+    if (!isInGitRepository()) {
+      tryGitInit()
+    }
+
+    // check if gitignore exist else add
+    const gitIgnorePath = path.join(manager.directory, '.gitignore')
+    if (!existsSync(gitIgnorePath)) {
+      const gitIgnoreString = generateGitIgnore()
+      writeFile(gitIgnorePath, gitIgnoreString)
+    }
+
+    let sourceUrl = cmdOptions.sshUrl
+
+    if (!sourceUrl) {
+      const createRes = await createRepo(manager.config.name)
+      sourceUrl = createRes.sshUrl
+    }
+
+    const source = {
+      ssh: sourceUrl.trim(),
+      https: convertGitSshUrlToHttps(sourceUrl.trim()),
+    }
+
+    spinnies.add('cr', { text: 'Adding source to blocks' })
+
+    if (manager.config.repoType === 'multi') {
+      manager.updateConfig({ source })
+      spinnies.succeed('cr', { text: 'Successfully added source to block' })
+      return
+    }
+
+    manager.updateConfig({ source })
+    await updateAllMemberConfig(manager, source)
+
+    spinnies.succeed('cr', { text: 'Successfully added source to blocks' })
+  } catch (error) {
+    spinnies.add('cr', { text: 'Adding source to blocks' })
+    spinnies.fail('cr', { text: error.message })
+  }
+}
+
+module.exports = connectRemote

--- a/subcommands/connectRemote/util.js
+++ b/subcommands/connectRemote/util.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const path = require('path')
+const ConfigFactory = require('../../utils/configManagers/configFactory')
+
+async function updateAllMemberConfig(manger, source) {
+  for await (const blockManager of manger.getDependencies()) {
+    if (!blockManager?.config) continue
+
+    const { type } = blockManager.config
+    // eslint-disable-next-line no-param-reassign
+    source.branch = `orphan-${manger.config.name}`
+    blockManager.updateConfig({ source })
+
+    if (type === 'package') {
+      await updateAllMemberConfig(blockManager, source)
+    }
+  }
+}
+
+async function initializeConfig() {
+  const configPath = path.resolve('block.config.json')
+  const { manager: configManager, error } = await ConfigFactory.create(configPath)
+  if (error) {
+    if (error.type !== 'OUT_OF_CONTEXT') throw error
+    throw new Error('Cannot run bb command outside of bb context')
+  }
+  return configManager
+}
+
+module.exports = { initializeConfig, updateAllMemberConfig }

--- a/subcommands/pushV2/plugins/HandleMonoRepoPush.js
+++ b/subcommands/pushV2/plugins/HandleMonoRepoPush.js
@@ -25,22 +25,13 @@ class HandleMonoRepoPush {
          */
         core
       ) => {
-        if (core.appConfig.config?.repoType !== 'mono') return
+        if (core.packageConfig?.repoType !== 'mono') return
 
+        const { blockName } = core.cmdArgs
         const { force } = core.cmdOpts
-        if (!force) return
+        if (!force || blockName) return
 
-        core.blocksToPush = [
-          {
-            directory: core.cwd,
-            meta: {
-              source: core.appConfig.config?.source,
-              name: core.appConfig.config?.name,
-              type: 'package',
-              repoType: 'mono',
-            },
-          },
-        ]
+        core.blocksToPush = [core.packageManager]
       }
     )
   }

--- a/subcommands/pushV2/plugins/HandleMultiRepoPush.js
+++ b/subcommands/pushV2/plugins/HandleMultiRepoPush.js
@@ -25,26 +25,17 @@ class HandleMultiRepoPush {
          */
         core
       ) => {
-        if (core.appConfig.config?.repoType !== 'multi') return
+        if (core.packageConfig?.repoType !== 'multi') return
 
+        const { blockName } = core.cmdArgs
         const { force } = core.cmdOpts
-        if (!force) return
+        
+        if (!force || blockName) return
 
-        const memberBlocks = [...core.appConfig.dependencies]
+        const memberBlocks = [...(await core.packageManager.getDependencies())]
+        core.packageManager.gitAddIgnore = `-- ${memberBlocks.map(({ directory }) => `':!${directory}'`).join(' ')}`
 
-        core.blocksToPush = [
-          ...core.blocksToPush,
-          {
-            directory: core.cwd,
-            gitAddIgnore: `-- ${memberBlocks.map(({ directory }) => `':!${directory}'`).join(' ')}`,
-            meta: {
-              source: core.appConfig.config?.source,
-              name: core.appConfig.config?.name,
-              type: 'package',
-              repoType: 'mono',
-            },
-          },
-        ]
+        core.blocksToPush = [...core.blocksToPush, core.packageManager]
       }
     )
   }

--- a/subcommands/pushV2/pushV2.js
+++ b/subcommands/pushV2/pushV2.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const { headLessConfigStore } = require('../../configstore')
 const { spinnies } = require('../../loader')
 const { feedback } = require('../../utils/cli-feedback')
 const { Logger } = require('../../utils/loggerV2')
@@ -16,12 +17,17 @@ const PushCore = require('./pushCore')
 async function push(blockName, cmdOptions) {
   const { logger } = new Logger('push')
   const Push = new PushCore(blockName, cmdOptions, { logger, spinnies, feedback })
+
+  if (process.env.BB_CLI_RUN_HEADLESS) {
+    global.HEADLESS_CONFIGS = headLessConfigStore.store
+  }
+
   try {
     new HandleBeforePush().apply(Push)
     new HandleMonoRepoPush().apply(Push)
     new HandleMultiRepoPush().apply(Push)
 
-    await Push.initializeAppConfig()
+    await Push.initializeConfig()
     await Push.pushBlocks()
   } catch (error) {
     logger.error(error)

--- a/subcommands/pushV2/utils/blockPusher.js
+++ b/subcommands/pushV2/utils/blockPusher.js
@@ -15,12 +15,12 @@ const traverse = require('@babel/traverse').default
 
 class BlockPusher {
   constructor(block, bar, noLogs) {
-    this.blockMeta = block
+    this.blockMeta = block.config
     this.blockPath = block.directory
-    this.blockName = block.meta.name
-    this.blockSource = block.meta.source
-    this.blockType = block.meta.type
-    this.repoType = block.meta.repoType
+    this.blockName = block.config.name
+    this.blockSource = block.config.source
+    this.blockType = block.config.type
+    this.repoType = block.config.repoType
     this.gitAddIgnore = block.gitAddIgnore
     this.progress = noLogs
       ? null

--- a/templates/createTemplates/function-templates/generate-gitignore.js
+++ b/templates/createTemplates/function-templates/generate-gitignore.js
@@ -1,4 +1,9 @@
 const generateGitIgnore = () => `
+#
+._ab_*
+.deploy
+.deployed.config.json
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
# Feat: bb push for nested package

This pull request includes hot fixes for two issues:

1. Update to `bb push` to compatible with package inside package
2. New command `bb connect-remote` to connect block to repository  

## bb push

bb push will loop through nested packages and push all blocks on force push, and selected block if block name is passed

## bb connect-remote

This command is used to connect local block to remote git repository, User can either pass the ssh-url or opt to create a repository form the cli.

    Usage: bb-connect-remote [options]
    
    Options:
      -f, --force                Force with new repository
      -ssh, --ssh-url <ssh-url>  Git ssh url of the repository
      -h, --help                 display help for command

eg:  `bb connect-remote -ssh git@github.com:user/block.git`