### PR TITLE
Refactor bb-exec & more filters

### DIFF
--- a/bin/bb-exec.cjs
+++ b/bin/bb-exec.cjs
@@ -8,14 +8,16 @@
  */
 
 const { Command } = require('commander')
-const exec = require('../subcommands/exec')
+const exec = require('../subcommands/exec-v2')
 
 const program = new Command()
 
 program
   .argument('<command>', 'command to run in quotes.eg:"ls"')
-  .option('-in,--inside <blocks...>', 'inside which block?')
-  .option('-g,--group', 'in a folder')
+  .option('-in,--inside <blocks...>', 'inside which block?', [])
+  .option('-t,--types <types...>', 'inside specific types', [])
+  .option('-g,--groups <groups...>', 'in a folder', [])
+  .option('-l,--limit <limit>', 'level', -1)
   .action(exec)
 
 program.parse(process.argv)

--- a/subcommands/exec-v2.js
+++ b/subcommands/exec-v2.js
@@ -1,0 +1,136 @@
+const path = require('path')
+const { exec } = require('child_process')
+const chalk = require('chalk')
+const ConfigFactory = require('../utils/configManagers/configFactory')
+const { Logger } = require('../utils/loggerV2')
+const PackageConfigManager = require('../utils/configManagers/packageConfigManager')
+const BlockConfigManager = require('../utils/configManagers/blockConfigManager')
+
+function pexec(cmd, options, name) {
+  return new Promise((resolve) => {
+    exec(cmd, options, (error, stdout, stderr) => {
+      if (error) {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({ name, out: stderr.toString(), err: true })
+        return
+      }
+      resolve({ name, out: stdout.toString(), err: false })
+    })
+  })
+}
+async function bbexecV2(command, options) {
+  const CONFIGNAME = 'block.config.json'
+
+  const { logger } = new Logger('exec')
+  logger.info('EXEC COMMAND STARTED')
+
+  const { groups, inside, types, limit } = options
+
+  /**
+   *
+   * @param {PackageConfigManager | BlockConfigManager} c a manager
+   * @returns {boolean}
+   */
+  const typeSatisfies = (c) => {
+    if (types.length === 0) return true
+    return types.includes(c.config.type)
+  }
+
+  /**
+   * Checks if passed manager name is in the names list given by the user
+   * @param {PackageConfigManager | BlockConfigManager} c a manager
+   * @returns {boolean}
+   */
+  const nameSatisfies = (c) => {
+    if (inside.length === 0) return true
+    return inside.includes(c.config.name)
+  }
+
+  /**
+   *
+   * @param {PackageConfigManager | BlockConfigManager} c a manager
+   * @returns {boolean}
+   */
+  const groupSatisfies = (c) => {
+    if (groups.length === 0) return true
+    const pathBits = c.pathRelativeToParent.split(path.sep)
+    return pathBits.some((b) => groups.includes(b))
+  }
+
+  /**
+   * For debug alone
+   */
+  logger.debug(`groupList-${groups.join(',')}`)
+  logger.debug(`insideList-${inside.join(',')}`)
+  logger.debug(`typelist-${types.join(',')}`)
+  logger.debug(`limit-${limit}`)
+
+  const { manager, e } = await ConfigFactory.create(path.resolve(CONFIGNAME))
+
+  if (e?.err) {
+    logger.error(e.err.message)
+    console.log(e.err.message)
+    process.exitCode = 1
+    return
+  }
+
+  /**
+   * @type {Set<string>}
+   */
+  const pathList = []
+  /**
+   * @type {Array<string>}
+   */
+  const roots = []
+
+  // If inside a package, traverse the tree and build pathList
+  if (manager instanceof PackageConfigManager) {
+    logger.info('User is inside a package')
+    roots.push(manager)
+    for (; roots.length > 0; ) {
+      const root = roots.pop()
+      for await (const m of root.getDependencies()) {
+        if (m instanceof PackageConfigManager) {
+          roots.push(m)
+        }
+        if (!groupSatisfies(m)) continue
+        if (!nameSatisfies(m)) continue
+        if (!typeSatisfies(m)) continue
+        pathList.push(m)
+      }
+    }
+  }
+
+  if (manager instanceof BlockConfigManager) {
+    logger.info('User is inside a block')
+    // If inside a block, Check if conditions satisfy
+    if (!groupSatisfies(manager)) {
+      console.log(`You are inside a block (${manager.config.name}) & is not inside any of the given groups`)
+    }
+    if (!nameSatisfies(manager)) {
+      console.log(`You are inside a block (${manager.config.name}) & it does not match any of the given block names`)
+    }
+    if (!typeSatisfies(manager)) {
+      console.log(`You are inside a block (${manager.config.name}) & it does not match any of the given block types`)
+    }
+    // if all conditions satisfy, add current block directory to pathList
+
+    pathList.push(manager)
+  }
+
+  console.log(`\n${chalk.whiteBright(command)} will be run in the following blocks\n`)
+  pathList.forEach((v) => {
+    console.log(`${chalk.blue(v.config.name)} : ${chalk.italic(v.directory)}`)
+    logger.info(v.directory)
+  })
+  console.log('\n')
+  Promise.allSettled(pathList.map((l) => pexec(command, { cwd: l.directory }, l.config.name))).then((res) => {
+    res.forEach((v) => {
+      const colour = v.value.err ? chalk.red : chalk.green
+      console.log(colour(v.value.name))
+      console.log(v.value.out)
+      console.log('\n')
+    })
+  })
+}
+module.exports = bbexecV2

--- a/utils/configManagers/configManager.d.ts
+++ b/utils/configManagers/configManager.d.ts
@@ -7,11 +7,11 @@ type Block_Author = {
 }
 
 export type BlockLiveDetails = {
-  isOn: boolean,
-  port: number,
-  pid: number?,
+  isOn: boolean
+  port: number
+  pid: ?number
   log: {
-    out: PathLike,
+    out: PathLike
     err: PathLike
   }
 }
@@ -75,29 +75,30 @@ export interface PackageConfig {
 type newConfig<T> = T extends PackageConfig ? Partial<PackageConfig> : Partial<BlockConfig>
 
 declare class ConfigManager<C extends BlockConfig | PackageConfig> {
-  constructor(config: C,configPath:string)
+  constructor(config: C, configPath: string)
 
   readonly id: number
   readonly configname: string
   readonly isWriting: boolean
   readonly liveConfigname: string
   events: EventEmitter
-  
-  _writeSignal: AbortSignal?;
-  _writeController:AbortController
-  _writeLiveSignal:AbortSignal?;
+
+  _writeSignal: ?AbortSignal
+  _writeController: AbortController
+  _writeLiveSignal: ?AbortSignal
 
   configPath: string
   config: C
   directory: string
-  liveConfigPath:string
-  liveDetails:BlockLiveDetails
-  
-  static WRITE_COUNTER:number
+  pathRelativeToParent: string
+  liveConfigPath: string
+  liveDetails: BlockLiveDetails
+
+  static WRITE_COUNTER: number
   static CONFIG_NAME: string
   static LIVE_CONFIG_NAME: string
   static LIVE_CONFIG_FILE_ROOT_PATH: string
-  private _write(configPath:string,data:object): void
+  private _write(configPath: string, data: object): void
   /**
    * Recursively moves up the current path,
    * reading block.config.json, checking for type package,
@@ -105,7 +106,7 @@ declare class ConfigManager<C extends BlockConfig | PackageConfig> {
    */
   public findMyParentPackage(): Promise<string>
   public isPackage(): config is PackageConfig
-  public init():Promise<void>
+  public init(): Promise<void>
 
   /**
    * Returns the updated config, also emits a write event

--- a/utils/configManagers/configManager.js
+++ b/utils/configManagers/configManager.js
@@ -20,6 +20,7 @@ class ConfigManager {
 
     this.configPath = configPath
     this.config = config
+    this.pathRelativeToParent = ''
     this.directory = path.dirname(configPath)
     this.liveConfigPath = path.join(
       ConfigManager.LIVE_CONFIG_FILE_ROOT_PATH,

--- a/utils/configManagers/packageConfigManager.js
+++ b/utils/configManagers/packageConfigManager.js
@@ -118,6 +118,7 @@ class PackageConfigManager extends ConfigManager {
         const relativeDirectory = this.config.dependencies[block].directory
         const configPath = path.join(this.directory, relativeDirectory, 'block.config.json')
         const { manager: c, error } = await _DYNAMIC_CONFIG_FACTORY.create(configPath)
+        c.pathRelativeToParent = relativeDirectory
         if (error) console.warn(chalk.yellow(`Error getting block config for ${block}`))
         const f = filter || (() => true)
         const p = picker || ((b) => b)


### PR DESCRIPTION
1. Refactor exec to work with new package managers
2. Add new filters `--type`, `--group` & `--limit` to exec command
```mermaid
  flowchart TD;
      A([Start])-->B[Generate manager with factory];
      B-->D{typeof manager?};
      D--PackageManager-->E[/till limit count is 0 or \nall levels are travelled\];
      E--> C[push all managers that \nsatisfy the conditions\n to pathList]
      C-->V[\done/];
      V-->X
      D--BlockManager-->F{run type filter};
      F--Pass-->G{run name filter };
      F--Fail-->I[Message and Abort];
      G--Pass-->K{run group filter };
      G--Fail-->I;
      K--Pass-->M[Push the node to pathList];
      K--Fail-->I;
      M-->X[execute the given command in blocks in pathList];
      X-->Z([Stop])
```

## TODO
1. `-l,--limit` is not implemented completely, passing a value will not have any effect now

## NOTES
1. `-g,--group` will only look for folder with any name in passed list, relative to the current package context while traversing, i.e if a group name of `view` is passed, program will look for `view` folder inside every package, it doesn't matter if directory tree previosly had `view` in path.
2. if user try to run command inside a block, it will be executed only if all given conditions are met.
