### PR TITLE
feat: middleware for function blocks

### DIFF
--- a/subcommands/createV2/createV2.js
+++ b/subcommands/createV2/createV2.js
@@ -30,7 +30,6 @@ async function create(blockName, cmdOptions) {
     await Create.initializePackageConfigManager()
     await Create.createBlock()
   } catch (error) {
-    console.log(error)
     logger.error(error)
     spinnies.add('create', { text: error.message })
     spinnies.fail('create', { text: error.message })

--- a/subcommands/startV2/plugins/handleBeforeStart.js
+++ b/subcommands/startV2/plugins/handleBeforeStart.js
@@ -1,7 +1,6 @@
 const treeKill = require('tree-kill')
 const isRunning = require('is-running')
 const { checkLanguageVersionExistInSystem } = require('../../languageVersion/util')
-const { getNodePackageInstaller } = require('../../../utils/nodePackageManager')
 // eslint-disable-next-line no-unused-vars
 const PackageConfigManager = require('../../../utils/configManagers/packageConfigManager')
 // eslint-disable-next-line no-unused-vars
@@ -19,11 +18,10 @@ class HandleBeforeStart {
         core
       ) => {
         global.rootDir = this.cwd
-        getNodePackageInstaller()
 
         const { blockName } = core.cmdArgs
         // If name exist check with config and dependencies
-        if (blockName && !core.packageManager.has(blockName)) {
+        if (blockName && !await core.packageManager.has(blockName)) {
           throw new Error(`Block ${blockName} not found in package ${core.packageConfig.name}`)
         }
 
@@ -38,7 +36,7 @@ class HandleBeforeStart {
         if ([...(await core.packageManager.nonLiveBlocks())].length === 0) {
           throw new Error(`All blocks are already live!`)
         }
-
+        
         // check if function or job exist when blockType passed as function
         if (core.cmdOpts.blockType === 'function' && ![...(await core.packageManager.fnBlocks())]?.length) {
           throw new Error(`No function blocks to start!`)

--- a/subcommands/startV2/plugins/handleNodeFunctionStart/generateEmulator.js
+++ b/subcommands/startV2/plugins/handleNodeFunctionStart/generateEmulator.js
@@ -20,69 +20,122 @@ const packageJson = () => `
   }
 }`
 
-const emulatorCode = (blockEmulateData, port) => `
-import express from "express"
-import http from "http"
-import cors from "cors"
-import path from "path"
+const emulatorCode = (port) =>
+  `
+  import express from "express";
+  import http from "http";
+  import cors from "cors";
+  import executeMiddleware from "./middlewareHandler.js";
+  import { getBlock } from "./utils.js";
+  
+  const appHandler = async (req, res, next) => {
+    try {
+      let url = req.params[0];
+  
+      if (url.includes("health")) {
+        req.params.health = "health";
+        url = url.split("/")[0]
+      }
+  
+      const { block, route } = getBlock(url);
+      if (!block) {
+        console.log("No block found for url ", url);
+        res.send("requested function not registered in app.").status(404);
+        res.end();
+        return;
+      }
+  
+      console.log("\\nRequest to block ", block.name);
 
-const appHandler = (type) => async (req, res, next) => {
-  try {
-    const blocks = ${JSON.stringify(blockEmulateData)}
+      // Execute middleware functions
+      await executeMiddleware(block.middlewares, { req, res, next });
+  
+      const isDev = process.env.NODE_ENV === "development";
+      const importPath = isDev ? route + "?update=" + Date.now() : route;
+      const handler = await import(importPath);
+  
+      console.log("handler: ", handler);
+      await handler.default({ req, res, next });
+    } catch (err) {
+      console.error(err);
+      res.send("Something went wrong. Please check function log").status(500);
+    }
+  };
+  
+  const app = express();
+  app.use(cors());
+  app.all("/*", appHandler);
+  
+  const server = http.createServer(app);
+  server.listen(${port});
+  console.log("Functions emulated on port ${port}");
+  
+`.trim()
 
-    const url = req.params[0]
+const generateMiddlewareHandler = () =>
+  `
+import { getMiddlewareBlock } from "./utils.js";
 
-    if (url.includes("health")) {
-      //check for health param and inject if needed
-      req.params.health = "health"
+const executeMiddleware = async (middlewareList, event) => {
+  for (const middlewareName of middlewareList) {
+    const isDev = process.env.NODE_ENV === "development";
+    const { block, route } = getMiddlewareBlock(middlewareName);
+    if (!block) {
+      console.log("No block found for ", middlewareName);
+      continue;
     }
 
-    console.log("url", url)
+    const importPath = isDev ? route + "?update=" + Date.now() : route;
 
-    const blockData = blocks[url]
-    if (!blockData) {
-      res.send("requested function not registered in app.").status(404)
-      return
-    }
-
-    const func_route = path.join(blockData.directory, "index.js" )
-    let handler = await import(func_route)
-    if (process.env.NODE_ENV === "development") {
-      handler = await import(func_route + "?update=" + Date.now())
-    }
-
-    console.log("handler = ", handler)
-
-    const event = { req, res, next }
-    await handler.default(event)
-
-  } catch (err) {
-    console.error(err)
-    res.send("Something went wrong. Please check function log").status(500)
+    const middlewareHandler = await import(importPath);
+    await middlewareHandler.default(event);
   }
-}
+};
 
-const app = express()
-app.use(cors())
-app.all("/*", appHandler("function"))
+export default executeMiddleware;
 
-const server = http.createServer(app)
-server.listen(${port})
-console.log("Functions emulated on port ${port}")
-`
+`.trim()
+
+const generateUtils = (blockList, middlewareBlockList) =>
+  `
+import path from "path";
+
+const getBlock = (url) => {
+  const blocks = ${JSON.stringify(blockList, null, 2)};
+
+  const block = blocks[url];
+  const route = block && path.join(block.directory, "index.js");
+
+  return { route, block };
+};
+
+const getMiddlewareBlock = (url) => {
+  const blocks = ${JSON.stringify(middlewareBlockList, null, 2)};
+
+  const block = blocks[url];
+  const route = block && path.join(block.directory, "index.js");
+
+  return { route, block };
+};
+
+export { getBlock, getMiddlewareBlock };
+
+`.trim()
 
 /**
  *
  * @param {import('fs').PathLike} emPath Emulator directory path
  * @returns
  */
-async function generateEmFolder(emPath, blockEmulateData, port) {
+async function generateEmFolder(emPath, blockList, port, middlewareBlockList) {
   const res = { err: false, data: '' }
   try {
     await mkdir(emPath, { recursive: true })
     await writeFile(path.join(emPath, '.gitignore'), '._ab_em/*')
-    await writeFile(path.join(emPath, 'index.js'), emulatorCode(blockEmulateData, port).trim())
+    await writeFile(path.join(emPath, 'index.js'), emulatorCode(port))
     await writeFile(path.join(emPath, 'package.json'), packageJson())
+    await writeFile(path.join(emPath, 'middlewareHandler.js'), generateMiddlewareHandler())
+    await writeFile(path.join(emPath, 'utils.js'), generateUtils(blockList, middlewareBlockList))
     res.data = 'completed'
   } catch (err) {
     res.err = true

--- a/subcommands/startV2/plugins/handleNodeFunctionStart/index.js
+++ b/subcommands/startV2/plugins/handleNodeFunctionStart/index.js
@@ -17,6 +17,7 @@ class HandleNodeFunctionStart {
   constructor() {
     this.fnBlocks = []
     this.blockEmulateData = {}
+    this.middlewareBlockListData = {}
     this.depsInstallReport = []
     this.port = 5000
     this.pid = 0
@@ -28,9 +29,8 @@ class HandleNodeFunctionStart {
    */
   apply(StartCore) {
     StartCore.hooks.beforeStart.tapPromise('HandleNodeFunctionStart', async (/** @type {StartCore} */ core) => {
-      
       if (core.cmdOpts.blockType && core.cmdOpts.blockType !== 'function') return
-      
+
       /**
        * Filter node fn blocks
        */
@@ -53,7 +53,18 @@ class HandleNodeFunctionStart {
           name: block.config.name,
           type: block.config.type,
           directory: block.directory,
-          relativeDirectory: block.directory,
+          middlewares: block.config.middlewares,
+          relativeDirectory: dir,
+        }
+      })
+
+      core.middlewareBlockList.forEach((block) => {
+        const dir = path.relative(path.resolve(), block.directory)
+        this.middlewareBlockListData[block.config.name] = {
+          name: block.config.name,
+          type: block.config.type,
+          directory: block.directory,
+          relativeDirectory: dir,
         }
       })
 
@@ -62,7 +73,12 @@ class HandleNodeFunctionStart {
        */
       this.port = this.fnBlocks[0].availablePort
 
-      const _emFolderGen = await generateEmFolder(emPath, this.blockEmulateData, this.port)
+      const _emFolderGen = await generateEmFolder(
+        emPath,
+        this.blockEmulateData,
+        this.port,
+        this.middlewareBlockListData
+      )
       if (_emFolderGen.err) {
         spinnies.fail('emBuild', { text: 'Function emulator build failed' })
         return
@@ -127,17 +143,32 @@ class HandleNodeFunctionStart {
         this.pid = child.pid
         await writeFile(path.join(emPath, '.emconfig.json'), `{"pid":${child.pid}}`)
 
+        const updateConfig = {
+          isOn: true,
+          singleInstance: true,
+          pid: this.pid || null,
+          port: this.port || null,
+          log: {
+            out: logOutPath,
+            err: logErrPath,
+          },
+        }
+
         for (const blockManager of this.fnBlocks) {
-          blockManager.updateLiveConfig({
-            isOn: true,
-            singleInstance: true,
-            pid: this.pid || null,
-            port: this.port || null,
-            log: {
-              out: logOutPath,
-              err: logErrPath,
-            },
-          })
+          blockManager.updateLiveConfig(updateConfig)
+        }
+
+        // update middleware block as live to avoid issues of some blocks are not start
+        for (const blockManager of core.middlewareBlockList) {
+          blockManager.updateLiveConfig(updateConfig)
+        }
+
+        // update middleware block as live to avoid issues of some blocks are not start
+        for (const { type, blocks } of core.blockStartGroups) {
+          if (type !== 'shared-fn') continue
+          for (const blockManager of blocks) {
+            blockManager.updateLiveConfig(updateConfig)
+          }
         }
 
         spinnies.succeed('emBuild', { text: `Function emulator started at http://localhost:${this.port}` })

--- a/subcommands/startV2/plugins/lockAndAssignPortsPlugin.js/index.js
+++ b/subcommands/startV2/plugins/lockAndAssignPortsPlugin.js/index.js
@@ -6,7 +6,7 @@ const { portNumbers } = require('../../../../utils/portFindHelper')
 const { Locked, getLocalHosts, getAvailablePort } = require('./utils')
 
 class LockAndAssignPorts {
-  constructor() {
+  setUpPort() {
     this.emPortFromEnv = parseInt(process.env.BB_EM_PORT, 10) || null
     this.elePortFromEnv = parseInt(process.env.BB_ELEMENTS_PORT, 10) || null
     this.containerPortFromEnv = parseInt(process.env.BB_CONTAINER_PORT, 10) || null
@@ -100,6 +100,8 @@ class LockAndAssignPorts {
       for (const block of blocksList) {
         block.updatePortConfig(g)
       }
+
+      return
     }
     for (const block of blocksList) {
       const g = await this.getPorts({ port: block.config.port || portNumbers(...this.map[type]) })
@@ -116,6 +118,7 @@ class LockAndAssignPorts {
          */
         core
       ) => {
+        this.setUpPort()
         for (const { type, blocks } of core.blockStartGroups) {
           if (!this.map[type]) continue
           await this.getLockedPorts(blocks, type)

--- a/subcommands/startV2/startCore.js
+++ b/subcommands/startV2/startCore.js
@@ -51,6 +51,9 @@ class StartCore {
      * @type {Iterable<{type:string,blocks:Array}>}>}
      */
     this.blockStartGroups = {}
+
+    this.middlewareBlockList = []
+
     this.hooks = {
       beforeStart: new AsyncSeriesHook(['core']),
       afterStart: new AsyncSeriesHook(['core']),
@@ -85,9 +88,10 @@ class StartCore {
   async cleanUp() {
     if (JSON.stringify(this.blockStartGroups) === '{}') return
     for (const { blocks } of this.blockStartGroups) {
-      blocks.forEach((v) => v.portKey?.abort())
+      for (const { portKey } of blocks) {
+        if (portKey) portKey.abort()
+      }
     }
-    process.exitCode = 0
   }
 }
 

--- a/subcommands/startV2/startV2.js
+++ b/subcommands/startV2/startV2.js
@@ -10,10 +10,10 @@ const LockAndAssignPorts = require('./plugins/lockAndAssignPortsPlugin.js')
 const HandleOutOfContext = require('./plugins/handleOutOfContext')
 const HandleBeforeStart = require('./plugins/handleBeforeStart')
 const HandleBlockGrouping = require('./plugins/handleBlockGrouping')
+const chalk = require('chalk')
 
 async function start(blockName, options) {
   const { logger } = new Logger('start')
-
   const Start = new StartCore(blockName, {
     singleInstance: !options.multiInstance,
     ...options,
@@ -22,25 +22,24 @@ async function start(blockName, options) {
     spinnies,
   })
 
-  new HandleBeforeStart().apply(Start)
-  new HandleOutOfContext().apply(Start)
-  new HandleBlockGrouping().apply(Start)
-  new LockAndAssignPorts().apply(Start)
-
-  new HandleNodeFunctionStart().apply(Start)
-  new HandleJSViewStart().apply(Start)
-
   try {
+    new HandleOutOfContext().apply(Start)
+    new HandleBeforeStart().apply(Start)
+    new HandleBlockGrouping().apply(Start)
+    new LockAndAssignPorts().apply(Start)
+
+    new HandleNodeFunctionStart().apply(Start)
+    new HandleJSViewStart().apply(Start)
+
     await Start.initializeConfigManager()
     await Start.start()
     await Start.cleanUp()
   } catch (error) {
-    spinnies.add('start', { text: error.message })
-    spinnies.fail('start', { text: error.message })
-    spinnies.stopAll()
-    console.log(error);
-    logger.error(error)
     await Start.cleanUp()
+    logger.error(error)
+    spinnies.stopAll()
+    spinnies.add('start', { text: error.message })
+    spinnies.fail('start', { text: chalk.red(error.message) })
   }
 }
 

--- a/subcommands/stopV2/plugins/handleBeforeStop.js
+++ b/subcommands/stopV2/plugins/handleBeforeStop.js
@@ -22,7 +22,8 @@ class HandleBeforeStop {
         }
         const blockManager = await core.packageManager.getBlock(blockName)
         core.blocksToStop = [blockManager]
-        if (!blockManager.liveDetails.singleInstance) throw new Error(`Block is started as single instance, Run bb stop`)
+        if (!blockManager.liveDetails.singleInstance)
+          throw new Error(`Block is started as single instance, Run bb stop`)
         if (!blockManager.liveDetails.isOn) throw new Error(`Block ${blockName} not live`)
         return
       }

--- a/subcommands/stopV2/plugins/handleOutOfContext.js
+++ b/subcommands/stopV2/plugins/handleOutOfContext.js
@@ -1,0 +1,23 @@
+// eslint-disable-next-line no-unused-vars
+const StartCore = require('../stopCore')
+
+class HandleOutOfContext {
+  // eslint-disable-next-line class-methods-use-this
+  apply(stopCore) {
+    stopCore.hooks.beforeStop.tapPromise(
+      'HandleOutOfContext',
+      async (
+        /**
+         * @type {StartCore}
+         */
+        core
+      ) => {
+        if (!core.isOutOfContext) return
+        throw new Error('Please run the command inside a package context')
+
+        // TODO: handle global stop from outside context
+      }
+    )
+  }
+}
+module.exports = HandleOutOfContext

--- a/subcommands/stopV2/stopV2.js
+++ b/subcommands/stopV2/stopV2.js
@@ -4,11 +4,13 @@ const { spinnies } = require('../../loader')
 const { feedback } = require('../../utils/cli-feedback')
 const HandleBeforeStop = require('./plugins/handleBeforeStop')
 const StopCore = require('./stopCore')
+const HandleOutOfContext = require('./plugins/handleOutOfContext')
 
 async function stop(blockName, options) {
   const { logger } = new Logger('start')
   try {
     const core = new StopCore(blockName, { ...options, logger, feedback, spinnies })
+    new HandleOutOfContext().apply(core)
     new HandleBeforeStop().apply(core)
 
     await core.initializeConfigManager()

--- a/templates/createTemplates/function-templates/generate-index.js
+++ b/templates/createTemplates/function-templates/generate-index.js
@@ -8,6 +8,7 @@ const handler = async (event) => {
   if (req.params.health === "health") {
     res.write(JSON.stringify({success: true, msg: "Health check success"}))
     res.end()
+    return
   }
 
   // Add your code here


### PR DESCRIPTION
# Feat: bb push for nested package

This pull request includes:

1. Update for integrating custom middleware for function blocks

  To add custom middleware user can create a function block and pass that block as middleware in config.json
  
  Format to pass middlewares in function block.config.json

      {
        //...rest block.config.json 
        "middlewares": [middlewareName]
      }
        
  Format to pass middlewares in package block.config.json

      {
        //...rest block.config.json 
        "middlewares": [
          {
            "executeOnBlocks": [], // Optional : if empty all functions are considered
            "middlewaresList": ["midBlockCommon"]
          },
          {
            "executeOnBlocks": ["fnBlockA", "fnBlockB"],
            "middlewaresList": ["midBlockA"]
          }
        ],
      }
              
  The order of execution of middlewares are in the order they are passed in array.
  For a block middlewares passed in package level (start level package) will be executed before the middlewares in that 
 block config 

2. Refactor on `bb start` and `bb stop` commands to accommodate new middleware
