### PR TITLE
feat: user settable pm2 name

### DIFF
--- a/subcommands/startV2/plugins/handleNodeFunctionStart/index.js
+++ b/subcommands/startV2/plugins/handleNodeFunctionStart/index.js
@@ -181,7 +181,7 @@ class HandleNodeFunctionStart {
           }
 
           const command = 'pm2'
-          pm2InstanceName = core.cmdArgs.blockName || core.packageConfig.name
+          pm2InstanceName = process.env.BB_PM2_NAME || core.cmdArgs.blockName || core.packageConfig.name
           let args = ['start', 'index.js', '-i', 'max', '--name', pm2InstanceName]
 
           if (existsSync('pm2.json')) {


### PR DESCRIPTION
user can pass a name for pm2 by setting `BB_P2_NAME`  in env.
for example `BB_PM2_NAME=Blue bb start -bt function -pm2`