### PR TITLE
fix: env warning duplicate issue

### DIFF
--- a/subcommands/startV2/plugins/handleJSViewStart/singleBuild/index.js
+++ b/subcommands/startV2/plugins/handleJSViewStart/singleBuild/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 /**
  * Copyright (c) Appblocks. and its affiliates.
  *
@@ -77,6 +78,9 @@ const singleBuild = async ({ core, ports, blocks, buildOnly = false, env }) => {
       }
 
       const updatedEnv = await upsertEnv('view', envUpdateData, env, envPrefixes)
+
+      core.envWarning.keys = core.envWarning.keys.concat(updatedEnv.envWarning.keys)
+      core.envWarning.prefixes = core.envWarning.prefixes.concat(updatedEnv.envWarning.prefixes)
 
       const emEleFolderName = '._ab_em_elements'
       const emEleFolder = path.join(relativePath, emEleFolderName)

--- a/subcommands/startV2/plugins/handleNodeFunctionStart/index.js
+++ b/subcommands/startV2/plugins/handleNodeFunctionStart/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 /* eslint-disable class-methods-use-this */
 const path = require('path')
 const { spawn, execSync } = require('child_process')
@@ -168,8 +169,14 @@ class HandleNodeFunctionStart {
           envPrefixes.push(pEnvPrefix)
         }
 
-        await upsertEnv('function', {}, environment, envPrefixes)
-        await upsertEnv('view', updateEnvValue, environment, envPrefixes)
+        const updatedFnEnv = await upsertEnv('function', {}, environment, envPrefixes)
+        const updatedViewEnv = await upsertEnv('view', updateEnvValue, environment, envPrefixes)
+        core.envWarning.keys = core.envWarning.keys
+          .concat(updatedFnEnv.envWarning.keys)
+          .concat(updatedViewEnv.envWarning.keys)
+        core.envWarning.prefixes = core.envWarning.prefixes
+          .concat(updatedFnEnv.envWarning.prefixes)
+          .concat(updatedViewEnv.envWarning.prefixes)
 
         let child = { pid: 0 }
         let pm2InstanceName

--- a/subcommands/startV2/startCore.js
+++ b/subcommands/startV2/startCore.js
@@ -3,6 +3,7 @@
  */
 
 const path = require('path')
+const chalk = require('chalk')
 const { AsyncSeriesHook } = require('tapable')
 const ConfigFactory = require('../../utils/configManagers/configFactory')
 const PackageConfigManager = require('../../utils/configManagers/packageConfigManager')
@@ -30,6 +31,10 @@ class StartCore {
     this.cwd = process.cwd()
 
     this.subPackages = {}
+    this.envWarning = {
+      keys: [],
+      prefixes: [],
+    }
 
     /**
      * @type {Logger}
@@ -82,7 +87,20 @@ class StartCore {
     await this.hooks.beforeStart?.promise(this, this.packageManager)
 
     // common core functionality if any
+    if (this.envWarning.keys?.length > 0) {
+      const keys = [...new Set(this.envWarning.keys)]
+      const prefixes = [...new Set(this.envWarning.prefixes)]
 
+      const affectedKeys = chalk.dim(`Environment keys affected: ${keys}`)
+      const egString = chalk.dim(
+        `Example: ${prefixes.map((pre) => `${pre}_${keys[0]} instead of ${keys[0]}`).join(' or ')}.`
+      )
+      const warnMessage = chalk.yellow(
+        `Beginning with the upcoming version,\nbb cli exclusively support environment keys that begin with "BB_<package>"`
+      )
+
+      console.log(`\n${warnMessage}\n\n${egString}\n\n${affectedKeys}`)
+    }
     // beforeCreate hook
     await this.hooks.afterStart?.promise(this, this.packageManager)
   }


### PR DESCRIPTION
This PR fixed the duplicate warning throwing multiple times on the same variable names for the format of environment variable without prefixing BB_packageName.
