### PR TITLE
fix: start issue with sub package

### DIFF
--- a/bin/bb-start.cjs
+++ b/bin/bb-start.cjs
@@ -19,6 +19,8 @@ program
   .option('-env, --environment <environment>', 'environment')
   .option('-bt, --block-type <block-type>', 'Block type to start')
   .option('-pm2, --pm2', 'Start functions with pm2')
+  .option('-sc, --sub-container', 'To start all sub container')
+  .option('-f, --force', 'To clear cache and start')
   .action(start)
 
 program.parse(process.argv)

--- a/bin/bb-start.cjs
+++ b/bin/bb-start.cjs
@@ -19,7 +19,7 @@ program
   .option('-env, --environment <environment>', 'environment')
   .option('-bt, --block-type <block-type>', 'Block type to start')
   .option('-pm2, --pm2', 'Start functions with pm2')
-  .option('-sc, --sub-container', 'To start all sub container')
+  .option('-nsc, --no-sub-container', 'To start all sub container')
   .option('-f, --force', 'To clear cache and start')
   .action(start)
 

--- a/subcommands/startV2/plugins/handleJSViewStart/utils.js
+++ b/subcommands/startV2/plugins/handleJSViewStart/utils.js
@@ -3,7 +3,7 @@ const path = require('path')
 const chalk = require('chalk')
 const readline = require('readline')
 const { Stream } = require('stream')
-const { createReadStream, watchFile } = require('fs')
+const { createReadStream, watchFile, existsSync, rmSync } = require('fs')
 const { runBash, runBashLongRunning } = require('../../../bash')
 const { getNodePackageInstaller } = require('../../../../utils/nodePackageManager')
 const { generateOutLogPath, generateErrLogPath } = require('../../../../utils/bbFolders')
@@ -98,6 +98,11 @@ async function startJsProgram(core, blockManager, port) {
 
   try {
     core.spinnies.update(name, { text: `Installing dependencies in ${name}` })
+
+    if (core.cmdOpts?.force) {
+      if (existsSync('./node_modules')) rmSync('./node_modules', { recursive: true })
+    }
+
     const { installer } = getNodePackageInstaller()
     const i = await runBash(installer, path.resolve(blockManager.directory))
     if (i.status === 'failed') throw new Error(i.msg)

--- a/subcommands/startV2/plugins/handleNodeFunctionStart/index.js
+++ b/subcommands/startV2/plugins/handleNodeFunctionStart/index.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable class-methods-use-this */
 const path = require('path')
+const chalk = require('chalk')
 const { spawn, execSync } = require('child_process')
-const { openSync, existsSync } = require('fs')
+const { openSync, existsSync, symlinkSync, rmSync } = require('fs')
 const { writeFile } = require('fs/promises')
 const { spinnies } = require('../../../../loader')
 const { pexec } = require('../../../../utils/execPromise')
@@ -10,7 +11,7 @@ const { generateEmFolder } = require('./generateEmulator')
 const { updateEmulatorPackageSingleBuild, linkEmulatedNodeModulesToBlocks } = require('./mergeData')
 const { getNodePackageInstaller } = require('../../../../utils/nodePackageManager')
 const { headLessConfigStore } = require('../../../../configstore')
-const { upsertEnv, readEnvAsObject } = require('../../../../utils/envManager')
+const { upsertEnv } = require('../../../../utils/envManager')
 const { readJsonAsync } = require('../../../../utils')
 const {
   getBBFolderPath,
@@ -39,6 +40,12 @@ class HandleNodeFunctionStart {
     StartCore.hooks.beforeStart.tapPromise('HandleNodeFunctionStart', async (/** @type {StartCore} */ core) => {
       if (core.cmdOpts.blockType && core.cmdOpts.blockType !== 'function') return
 
+      const emPath = getBBFolderPath(BB_FOLDERS.FUNCTIONS_EMULATOR, core.cwd)
+
+      if (core.cmdOpts?.force) {
+        if (existsSync(emPath)) rmSync(emPath, { recursive: true })
+      }
+
       /**
        * Filter node fn blocks
        */
@@ -51,8 +58,6 @@ class HandleNodeFunctionStart {
       }
 
       if (!this.fnBlocks.length) return
-
-      const emPath = getBBFolderPath(BB_FOLDERS.FUNCTIONS_EMULATOR, core.cwd)
 
       const { installer } = getNodePackageInstaller()
       const { FUNCTIONS_LOG } = BB_FILES
@@ -147,17 +152,22 @@ class HandleNodeFunctionStart {
       }
 
       if (headlessConfig.prismaSchemaFolderPath) {
-        const ie = await pexec('npx prisma generate', { cwd: headlessConfig.prismaSchemaFolderPath })
-        if (ie.err) throw new Error(ie.err)
-
-        const envPath = path.join(path.resolve(), `.env.function${environment ? `.${environment}` : ''}`)
-        const existEnvData = await readEnvAsObject(envPath)
-
-        const subPackagePrefix = subPackageNames.find((s) => headlessConfig.prismaSchemaFolderPath.includes(s))
-        let dbEnv = existEnvData[`BB_${currentPackEnvPrefix}_DATABASE_URL`]
-        if (subPackagePrefix) dbEnv = existEnvData[`BB_${subPackagePrefix.toUpperCase()}_DATABASE_URL`]
-
-        if (dbEnv) execSync(`export BB_${currentPackEnvPrefix}_DATABASE_URL=${dbEnv}`)
+        const envName = `.env.function${environment ? `.${environment}` : ''}`
+        const envPath = path.join(path.resolve(), envName)
+        if (existsSync(envPath) && existsSync(headlessConfig.prismaSchemaFolderPath)) {
+          try {
+            const dest = path.resolve(headlessConfig.prismaSchemaFolderPath, envName)
+            symlinkSync(envPath, dest)
+          } catch (error) {
+            if (error.code !== 'EEXIST') throw error
+          }
+          const ie = await pexec('npx prisma generate', { cwd: headlessConfig.prismaSchemaFolderPath })
+          if (ie.err) throw new Error(ie.err)
+        } else {
+          console.log(
+            chalk.warn(`Path ${!existsSync(envPath) ? envPath : headlessConfig.prismaSchemaFolderPath} not found`)
+          )
+        }
       }
 
       spinnies.update('emBuild', { text: 'Starting emulator' })


### PR DESCRIPTION
Changes 

- [x] Add symlink to prisma env 
- [x] Add --force flag to clear emulators before start
- [x] Add --no-sub-container flag to avoid starting sub container  


Note: Please merge this only after node-sdk v0.0.7 [https://www.npmjs.com/package/@appblocks/node-sdk] is released