### PR TITLE
feat: add env for preview

### DIFF
--- a/bin/bb-set-preview-env.cjs
+++ b/bin/bb-set-preview-env.cjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { Command } = require('commander')
+const setPreviewEnvVariable = require('../subcommands/setPreviewEnvVariable')
+
+const program = new Command()
+
+program
+  .argument('[env...]', 'Environment variables (separated by spaces)')
+  .option('-fp, --file-path <file-path>', 'file-path of env', '.env.preview')
+  .action(setPreviewEnvVariable)
+
+program.parse(process.argv)

--- a/bin/bb.cjs
+++ b/bin/bb.cjs
@@ -78,6 +78,8 @@ cmd('get', 'To get free blocks from the store')
 
 cmd('rename', 'To rename block')
 
+cmd('set-preview-env', 'To set preview environment variables')
+
 // eslint-disable-next-line no-unused-expressions
 ;(async () => {
   await checkEngineSupport(packageJson)

--- a/subcommands/setPreviewEnvVariable.js
+++ b/subcommands/setPreviewEnvVariable.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Appblocks. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const path = require('path')
+const { existsSync } = require('fs')
+const { readFile } = require('fs/promises')
+const { feedback } = require('../utils/cli-feedback')
+const { post } = require('../utils/axios')
+const { upsertPreviewEnvVariable } = require('../utils/api')
+const ConfigFactory = require('../utils/configManagers/configFactory')
+const { BB_CONFIG_NAME } = require('../utils/constants')
+const { spinnies } = require('../loader')
+const { getAllBlockVersions } = require('../utils/registryUtils')
+const { readInput } = require('../utils/questionPromptsV2')
+
+const setPreviewEnvVariable = async (args, options) => {
+  try {
+    const envPath = options.filePath
+
+    if (args.length > 0 && envPath !== '.env.preview') {
+      throw new Error(`Found both arguments and file path.\nPlease provide either variables as arguments or file`)
+    }
+
+    let variableData = []
+    if (args.length > 0) {
+      variableData = args
+    } else {
+      if (!existsSync(envPath)) throw new Error(`File not found`)
+      const envFileData = await readFile(envPath, 'utf8')
+      variableData = envFileData.split('\n')
+    }
+
+    spinnies.add('cr', { text: 'Initializing Config' })
+    const manager = await initializeConfig()
+    spinnies.remove('cr')
+
+    if (manager.config.type !== 'package') {
+      throw new Error('Please run the command inside package')
+    }
+
+    const { blockId } = manager.config
+    spinnies.add('bv', { text: `Checking block versions` })
+    const bkRes = await getAllBlockVersions(blockId)
+    spinnies.remove('bv')
+
+    const bkResData = bkRes.data?.data || []
+
+    if (bkResData.length < 1) {
+      throw new Error('No block versions found')
+    }
+
+    const blockVersions = bkResData.map((d) => ({
+      name: d.version_number,
+      value: d.id,
+    }))
+
+    const blockVersionId = await readInput({
+      type: 'list',
+      name: 'blockVersionId',
+      message: 'Select the block version',
+      choices: blockVersions,
+    })
+
+    variableData = variableData.reduce((a, eData) => {
+      const equalIndex = eData.indexOf('=')
+      const key = eData.substring(0, equalIndex)
+      const value = eData.substring(equalIndex + 1)
+      if (key?.length) a.push({ key, value })
+      return a
+    }, [])
+
+    spinnies.add('bv', { text: `Saving environment variables` })
+    const { error } = await post(upsertPreviewEnvVariable, {
+      variables: variableData,
+      block_version_id: blockVersionId,
+    })
+    spinnies.remove('bv')
+
+    if (error) throw error
+
+    spinnies.stopAll()
+    feedback({ type: 'success', message: 'Environment variables saved successfully' })
+  } catch (err) {
+    spinnies.stopAll()
+    feedback({ type: 'error', message: err.message })
+  }
+}
+
+async function initializeConfig() {
+  const configPath = path.resolve(BB_CONFIG_NAME)
+  const { manager: configManager, error } = await ConfigFactory.create(configPath)
+  if (error) {
+    if (error.type !== 'OUT_OF_CONTEXT') throw error
+    throw new Error('Please run the command inside package context ')
+  }
+  return configManager
+}
+
+module.exports = setPreviewEnvVariable

--- a/utils/api.js
+++ b/utils/api.js
@@ -67,6 +67,7 @@ api.submitForDependenciesReview = `${api.appBlockRegistryOrigin}/api/registry/v0
 api.linkAbVersionBlockVersion = `${api.appBlockRegistryOrigin}/api/registry/v0.1/link-ab-version-to-block-version/invoke`
 api.getBlockFromStore = `${api.appBlockRegistryOrigin}/api/registry/v0.1/get-block-from-store/invoke`
 api.checkBlocksSyncedApi = `${api.appBlockRegistryOrigin}/api/registry/v0.1/check-is-synced/invoke`
+api.upsertPreviewEnvVariable = `${api.appBlockRegistryOrigin}/api/registry/v0.1/upsert-preview-env-variables/invoke`
 
 // APP-REGISTRY
 api.appBlockAppRegistryOrigin = APP_REG_BASE_URL


### PR DESCRIPTION
- [x] Command to add preview environment variables

```
Usage: bb-set-preview-env [options] [env...]

Arguments:
  env                           Environment variables (separated by spaces)

Options:
  -fp, --file-path <file-path>  file-path of env (default: ".env.preview")
  -h, --help                    display help for command
  
```